### PR TITLE
Remove macro defined versions from catch.hpp

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,3 +79,14 @@ jobs:
           name: ${{github.job}}
           path: ${{github.workspace}}/**/*
           retention-days: 2
+          
+  style_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: DoozyX/clang-format-lint-action@v0.13
+        with:
+          source: './libudpard ./tests'
+          exclude: './tests/catch'
+          extensions: 'c,h,cpp,hpp'
+          clangFormatVersion: ${{ env.LLVM_VERSION }}

--- a/tests/catch/catch.hpp
+++ b/tests/catch/catch.hpp
@@ -13,10 +13,6 @@
 // start catch.hpp
 
 
-#define CATCH_VERSION_MAJOR 2
-#define CATCH_VERSION_MINOR 13
-#define CATCH_VERSION_PATCH 5
-
 #ifdef __clang__
 #    pragma clang system_header
 #elif defined __GNUC__


### PR DESCRIPTION
Macro defined constants result in errors when running `make VERBOSE=1` as it is against cpp core guidelines macros usage.