### PR TITLE
Remove single frame transfer CRC on receive

### DIFF
--- a/libudpard/udpard.c
+++ b/libudpard/udpard.c
@@ -888,8 +888,6 @@ UDPARD_PRIVATE int8_t rxSessionAcceptFrame(UdpardInstance* const          ins,
         rxs->transfer_timestamp_usec = frame->timestamp_usec;
     }
 
-    const bool single_frame = frame->start_of_transfer && frame->end_of_transfer;
-
     rxs->calculated_crc = crcAdd(rxs->calculated_crc, frame->payload_size, frame->payload);
 
     int8_t out = rxSessionWritePayload(ins, rxs, extent, frame->payload_size, frame->payload);
@@ -912,8 +910,9 @@ UDPARD_PRIVATE int8_t rxSessionAcceptFrame(UdpardInstance* const          ins,
 
             // Cut off the CRC from the payload if it's there -- we don't want to expose it to the user.
             UDPARD_ASSERT(rxs->total_payload_size >= rxs->payload_size);
+            // For single frame transfers, the truncated amount will be 0 (total_payload_size == payload_size)
             const size_t truncated_amount = rxs->total_payload_size - rxs->payload_size;
-            if ((!single_frame) && (CRC_SIZE_BYTES > truncated_amount))  // Single-frame transfers don't have CRC.
+            if (CRC_SIZE_BYTES > truncated_amount)
             {
                 UDPARD_ASSERT(out_transfer->payload_size >= (CRC_SIZE_BYTES - truncated_amount));
                 out_transfer->payload_size -= CRC_SIZE_BYTES - truncated_amount;

--- a/tests/test_private_rx.cpp
+++ b/tests/test_private_rx.cpp
@@ -481,7 +481,7 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(transfer.metadata.port_id == 2'222);
     REQUIRE(transfer.metadata.remote_node_id == 55);
     REQUIRE(transfer.metadata.transfer_id == 11);
-    REQUIRE(transfer.payload_size == 7);
+    REQUIRE(transfer.payload_size == 3); // Payload size should not include the CRC (3 byte payload + 4 byte CRC)
     REQUIRE(0 == std::memcmp(transfer.payload, "\x01\x01\x01", 3));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
@@ -515,7 +515,7 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(transfer.metadata.port_id == 2'222);
     REQUIRE(transfer.metadata.remote_node_id == 55);
     REQUIRE(transfer.metadata.transfer_id == 12);
-    REQUIRE(transfer.payload_size == 7);
+    REQUIRE(transfer.payload_size == 3); // Payload size should not include the CRC (3 byte payload + 4 byte CRC)
     REQUIRE(0 == std::memcmp(transfer.payload, "\x03\x03\x03", 3));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
@@ -550,7 +550,7 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(transfer.metadata.port_id == 2'222);
     REQUIRE(transfer.metadata.remote_node_id == 55);
     REQUIRE(transfer.metadata.transfer_id == 12);
-    REQUIRE(transfer.payload_size == 7);
+    REQUIRE(transfer.payload_size == 3); // Payload size should not include the CRC (3 byte payload + 4 byte CRC)
     REQUIRE(0 == std::memcmp(transfer.payload, "\x05\x05\x05", 3));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);

--- a/tests/test_public_roundtrip.cpp
+++ b/tests/test_public_roundtrip.cpp
@@ -107,7 +107,7 @@ TEST_CASE("RoundtripSimple")
                 {
                     if (result > 1)
                     {
-                        std::cout << "Warning: Multiframe transfer" << std::endl;
+                        // std::cout << "Warning: Multiframe transfer" << std::endl;
                     }
                     pending_transfers.emplace(timestamp_usec, Pending{tran, payload_size, payload});
                     frames_in_flight += static_cast<std::uint64_t>(result);

--- a/tests/test_public_roundtrip.cpp
+++ b/tests/test_public_roundtrip.cpp
@@ -107,7 +107,7 @@ TEST_CASE("RoundtripSimple")
                 {
                     if (result > 1)
                     {
-                        // std::cout << "Warning: Multiframe transfer" << std::endl;
+                        std::cout << "Warning: Multiframe transfer" << std::endl;
                     }
                     pending_transfers.emplace(timestamp_usec, Pending{tran, payload_size, payload});
                     frames_in_flight += static_cast<std::uint64_t>(result);

--- a/tests/test_public_rx.cpp
+++ b/tests/test_public_rx.cpp
@@ -122,10 +122,11 @@ TEST_CASE("RxBasic0")
     header.frame_index_eot                = (1U << 31U) + 1U;
     header.priority                       = 0b001;
     header.transfer_id                    = 0;
-    header.data_specifier                 = 0b0000110011001100;
+    header.data_specifier                 = 0b0000110011001100; // Subject ID = 3276
     specifier.data_specifier              = UDPARD_UDP_PORT;
     specifier.destination_route_specifier = 0b11101111'00'01000'0'0'000110011001100;
     specifier.source_route_specifier      = 0b11000000'10101000'00000000'00100111;
+    // This is an empty payload, the last four bytes are CRC.
     REQUIRE(1 == accept(0, 100'000'001, header, specifier, {0, 0, 0, 0}));
     REQUIRE(subscription != nullptr);
     REQUIRE(subscription->port_id == 0b0110011001100);
@@ -135,7 +136,7 @@ TEST_CASE("RxBasic0")
     REQUIRE(transfer.metadata.port_id == 0b0110011001100);
     REQUIRE(transfer.metadata.remote_node_id == 0b0100111);
     REQUIRE(transfer.metadata.transfer_id == 0);
-    REQUIRE(transfer.payload_size == 4);
+    REQUIRE(transfer.payload_size == 0); // Payload size should not include the CRC (0 byte payload + 4 byte CRC)
     REQUIRE(0 == std::memcmp(transfer.payload, "", 0));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 2);  // The SESSION and the PAYLOAD BUFFER.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (sizeof(RxSession) + 16));
@@ -156,7 +157,6 @@ TEST_CASE("RxBasic0")
     specifier.data_specifier              = UDPARD_UDP_PORT;
     specifier.destination_route_specifier = 0b11101111'00'01000'1'00000000'00011010;
     specifier.source_route_specifier      = 0b11000000'10101000'00000000'00100111;
-
     REQUIRE(0 == accept(0, 100'000'002, header, specifier, {0, 0, 0, 0}));
     REQUIRE(subscription == nullptr);
 
@@ -193,7 +193,7 @@ TEST_CASE("RxBasic0")
     REQUIRE(transfer.metadata.port_id == 0b0000110011);
     REQUIRE(transfer.metadata.remote_node_id == 0b0100101);
     REQUIRE(transfer.metadata.transfer_id == 4);
-    REQUIRE(transfer.payload_size == 7);
+    REQUIRE(transfer.payload_size == 3); // Payload size should not include the CRC (3 byte payload + 4 byte CRC)
     REQUIRE(0 == std::memcmp(transfer.payload, "\x01\x02\x03\x1E\xF2\x30\xF1", 7));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 4);  // Two SESSIONS and two PAYLOAD BUFFERS.
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (2 * sizeof(RxSession) + 16 + 20));
@@ -276,7 +276,7 @@ TEST_CASE("RxBasic0")
     REQUIRE(transfer.metadata.port_id == 0b0000111100);
     REQUIRE(transfer.metadata.remote_node_id == 0b0011011);
     REQUIRE(transfer.metadata.transfer_id == 5);
-    REQUIRE(transfer.payload_size == 5);
+    REQUIRE(transfer.payload_size == 1); // Payload size should not include the CRC (1 byte payload + 4 byte CRC)
     REQUIRE(0 == std::memcmp(transfer.payload, "\x05\x4D\x47\x8C\x67", 5));
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 4);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (2 * sizeof(RxSession) + 10 + 20));


### PR DESCRIPTION
Remove single frame transfer CRC on receive so that is not exposed to the user