### PR TITLE
Restart RX Session if out-of-order multiframe transfer received

### DIFF
--- a/libudpard/udpard.c
+++ b/libudpard/udpard.c
@@ -976,9 +976,9 @@ UDPARD_PRIVATE int8_t rxSessionUpdate(UdpardInstance* const          ins,
         // multi-frame transfer
         if (!(frame->start_of_transfer && frame->end_of_transfer))
         {
-            uint32_t next_expected_frame_index = (1U << UDPARD_END_OF_TRANSFER_OFFSET) + rxs->last_udp_header_index + 1;
             if (frame->end_of_transfer)
             {
+                uint32_t next_expected_frame_index = (1U << UDPARD_END_OF_TRANSFER_OFFSET) + rxs->last_udp_header_index + 1;
                 if (frame->frame_index != next_expected_frame_index)
                 {
                     // Out of order multiframe packet received

--- a/tests/test_public_roundtrip.cpp
+++ b/tests/test_public_roundtrip.cpp
@@ -170,19 +170,15 @@ TEST_CASE("RoundtripSimple")
 
                 UdpardRxTransfer      transfer{};
                 UdpardRxSubscription* subscription = nullptr;
-                std::int8_t           result =
-                    ins_rx.rxAccept(ti->tx_deadline_usec, ti->frame, 0, ti->specifier, transfer, &subscription);
-                REQUIRE(((-UDPARD_ERROR_OUT_OF_ORDER == ins_rx.rxAccept(ti->tx_deadline_usec,
-                                             ti->frame,
-                                             1,
-                                             ti->specifier,
-                                             transfer,
-                                             &subscription)) || (0 == ins_rx.rxAccept(ti->tx_deadline_usec,
-                                             ti->frame,
-                                             1,
-                                             ti->specifier,
-                                             transfer,
-                                             &subscription))));  // Redundant interface will never be used here.
+
+                std::int8_t result = ins_rx.rxAccept(
+                    ti->tx_deadline_usec,
+                    ti->frame,
+                    0,
+                    ti->specifier,
+                    transfer,
+                    &subscription);
+
                 if (result == 1)
                 {
                     Pending reference{};  // Fetch the reference transfer from the list of pending.


### PR DESCRIPTION
During on-target testing, it was found that if a frame is received out of order during a multiframe transfer, then libudpard cannot receive any subsequent transfers for any port IDs because it reports an out of memory error. This is because the memory allocated for the out-of-order multiframe transfer is never freed. Since out-of-order multiframe transfers are not currently supported, the best course of action is drop the entire payload and require the user to resend it. 