### PR TITLE
Add check to verify that the correct RX session transport index is updated in rxSessionUpdate

### DIFF
--- a/libudpard/udpard.c
+++ b/libudpard/udpard.c
@@ -948,13 +948,18 @@ UDPARD_PRIVATE int8_t rxSessionUpdate(UdpardInstance* const          ins,
     UDPARD_ASSERT(rxs->transfer_id <= UDPARD_TRANSFER_ID_MAX);
     UDPARD_ASSERT(frame->transfer_id <= UDPARD_TRANSFER_ID_MAX);
 
+    int8_t out = 0;
+    if(rxs->redundant_transport_index != redundant_transport_index)
+    {
+        return out;
+    }
+
     const bool tid_timed_out = (frame->timestamp_usec > rxs->transfer_timestamp_usec) &&
                                ((frame->timestamp_usec - rxs->transfer_timestamp_usec) > transfer_id_timeout_usec);
 
     const bool not_previous_tid = rxComputeTransferIDDifference(rxs->transfer_id, frame->transfer_id) > 1;
 
-    const bool need_restart = tid_timed_out || ((rxs->redundant_transport_index == redundant_transport_index) &&
-                                                frame->start_of_transfer && not_previous_tid);
+    const bool need_restart = tid_timed_out || (frame->start_of_transfer && not_previous_tid);
 
     if (need_restart)
     {
@@ -966,7 +971,6 @@ UDPARD_PRIVATE int8_t rxSessionUpdate(UdpardInstance* const          ins,
         rxs->last_udp_header_index     = 0U;
     }
 
-    int8_t out = 0;
     if (need_restart && (!frame->start_of_transfer))
     {
         rxSessionRestart(ins, rxs);  // SOT-miss, no point going further.
@@ -1003,9 +1007,9 @@ UDPARD_PRIVATE int8_t rxSessionUpdate(UdpardInstance* const          ins,
                 rxs->last_udp_header_index = frame->frame_index;
             }
         }
-        const bool correct_transport = (rxs->redundant_transport_index == redundant_transport_index);
-        const bool correct_tid       = (frame->transfer_id == rxs->transfer_id);
-        if (correct_transport && correct_tid)
+
+        const bool correct_tid = (frame->transfer_id == rxs->transfer_id);
+        if (correct_tid)
         {
             out = rxSessionAcceptFrame(ins, rxs, frame, extent, out_transfer);
         }

--- a/libudpard/udpard.h
+++ b/libudpard/udpard.h
@@ -541,6 +541,7 @@ UdpardTxQueueItem* udpardTxPop(UdpardTxQueue* const que, const UdpardTxQueueItem
 ///     - The received frame is a valid Cyphal/UDP transport frame, but there is no matching subscription,
 ///       the frame did not complete a transfer, the frame forms an invalid frame sequence, the frame is a duplicate,
 ///       the frame is unicast to a different node (address mismatch).
+///     - The redundant transport index does match the transport index for the RX session.
 int8_t udpardRxAccept(UdpardInstance* const         ins,
                       const UdpardMicrosecond       timestamp_usec,
                       UdpardFrame* const            frame,

--- a/tests/test_private_rx.cpp
+++ b/tests/test_private_rx.cpp
@@ -436,10 +436,10 @@ TEST_CASE("rxSessionUpdate")
 
     RxSession rxs;
     RxSession rxs_1;
-    rxs.transfer_id               = 31;
-    rxs.redundant_transport_index = 1;
+    rxs.transfer_id                 = 31;
+    rxs.redundant_transport_index   = 1;
     rxs_1.transfer_id               = 32;
-    rxs_1.redundant_transport_index = 1;
+    rxs_1.redundant_transport_index = 2;
 
     UdpardRxTransfer transfer{};
 
@@ -489,7 +489,7 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
     ins.getAllocator().deallocate(transfer.payload);
 
-    // Valid next transfer, wrong transport.
+    // Valid next transfer, wrong transport index.
     frame.timestamp_usec = 10'000'100;
     frame.transfer_id    = 12;
     frame.payload        = reinterpret_cast<const uint8_t*>("\x02\x02\x02\x6E\xB1\x75\xE9");
@@ -535,17 +535,17 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(rxs.transfer_id == 13U);
     REQUIRE(rxs.redundant_transport_index == 1);
 
-    // Restart due to TID timeout, switch iface.
+    // Restart due to TID timeout.
     frame.timestamp_usec = 20'000'000;
     frame.transfer_id    = 12;
     frame.payload        = reinterpret_cast<const uint8_t*>("\x05\x05\x05\xA9\x78\x22\x33");
-    REQUIRE(1 == update(0, 1'000'000, 16));
+    REQUIRE(1 == update(1, 1'000'000, 16));
     REQUIRE(rxs.transfer_timestamp_usec == 20'000'000);
     REQUIRE(rxs.payload_size == 0);
     REQUIRE(rxs.payload == nullptr);
     REQUIRE(rxs.calculated_crc == 0xFFFFFFFFU);
     REQUIRE(rxs.transfer_id == 13U);
-    REQUIRE(rxs.redundant_transport_index == 0);
+    REQUIRE(rxs.redundant_transport_index == 1);
     REQUIRE(transfer.timestamp_usec == 20'000'000);
     REQUIRE(transfer.metadata.priority == UdpardPrioritySlow);
     REQUIRE(transfer.metadata.transfer_kind == UdpardTransferKindMessage);
@@ -563,27 +563,27 @@ TEST_CASE("rxSessionUpdate")
     frame.transfer_id     = 13;
     frame.end_of_transfer = false;
     frame.payload_size    = 7;
-    frame.frame_index = 1;
+    frame.frame_index     = 1;
     frame.payload         = reinterpret_cast<const uint8_t*>("\x06\x06\x06\x06\x06\x06\x06");
-    REQUIRE(0 == update(0, 1'000'000, 16));
+    REQUIRE(0 == update(1, 1'000'000, 16));
 
     REQUIRE(rxs.transfer_timestamp_usec == 20'000'100);
     REQUIRE(rxs.payload_size == 7);
     REQUIRE(0 == std::memcmp(rxs.payload, "\x06\x06\x06\x06\x06\x06\x06", 7));
     REQUIRE(rxs.calculated_crc == crc("\x06\x06\x06\x06\x06\x06\x06"));
     REQUIRE(rxs.transfer_id == 13U);
-    REQUIRE(rxs.redundant_transport_index == 0);
+    REQUIRE(rxs.redundant_transport_index == 1);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
 
     // Update another session using same frame.
-    REQUIRE(0 == updateAnotherSession(1, 1'000'000, 16));
+    REQUIRE(0 == updateAnotherSession(2, 1'000'000, 16));
     REQUIRE(rxs_1.transfer_timestamp_usec == 20'000'100);
     REQUIRE(rxs_1.payload_size == 7);
     REQUIRE(0 == std::memcmp(rxs_1.payload, "\x06\x06\x06\x06\x06\x06\x06", 7));
     REQUIRE(rxs_1.calculated_crc == crc("\x06\x06\x06\x06\x06\x06\x06"));
     REQUIRE(rxs_1.transfer_id == 13U);
-    REQUIRE(rxs_1.redundant_transport_index == 1);
+    REQUIRE(rxs_1.redundant_transport_index == 2);
     REQUIRE(ins_1.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins_1.getAllocator().getTotalAllocatedAmount() == 16);
 
@@ -594,7 +594,7 @@ TEST_CASE("rxSessionUpdate")
     frame.frame_index       = 3 + static_cast<uint32_t>(1U << static_cast<uint32_t>(31U));
     frame.payload_size      = 2;
     frame.payload           = reinterpret_cast<const uint8_t*>("\x09\x09");
-    REQUIRE(-UDPARD_ERROR_OUT_OF_ORDER == update(0, 1'000'000, 16));
+    REQUIRE(-UDPARD_ERROR_OUT_OF_ORDER == update(1, 1'000'000, 16));
     // The session should be restarted if an out of order frame is received
     // and the entire transfer will be dropped. Verify that all variables have
     // been set back to defaults by rxSessionRestart.
@@ -603,7 +603,7 @@ TEST_CASE("rxSessionUpdate")
     REQUIRE(rxs.payload == NULL);
     REQUIRE(rxs.calculated_crc == CRC_INITIAL);
     // Update another session using same frame, fail.
-    REQUIRE(-UDPARD_ERROR_OUT_OF_ORDER == updateAnotherSession(1, 1'000'000, 16));
+    REQUIRE(-UDPARD_ERROR_OUT_OF_ORDER == updateAnotherSession(2, 1'000'000, 16));
     REQUIRE(rxs_1.total_payload_size == 0U);
     REQUIRE(rxs_1.payload_size == 0U);
     REQUIRE(rxs_1.payload == NULL);
@@ -620,25 +620,25 @@ TEST_CASE("rxSessionUpdate")
     frame.payload_size    = 7;
     frame.frame_index     = 1;
     frame.payload         = reinterpret_cast<const uint8_t*>("\x06\x06\x06\x06\x06\x06\x06");
-    REQUIRE(0 == update(0, 1'000'000, 16));
+    REQUIRE(0 == update(1, 1'000'000, 16));
 
     REQUIRE(rxs.transfer_timestamp_usec == 20'000'300);
     REQUIRE(rxs.payload_size == 7);
     REQUIRE(0 == std::memcmp(rxs.payload, "\x06\x06\x06\x06\x06\x06\x06", 7));
     REQUIRE(rxs.calculated_crc == crc("\x06\x06\x06\x06\x06\x06\x06"));
     REQUIRE(rxs.transfer_id == 14U);
-    REQUIRE(rxs.redundant_transport_index == 0);
+    REQUIRE(rxs.redundant_transport_index == 1);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
 
     // Update another session using same frame.
-    REQUIRE(0 == updateAnotherSession(1, 1'000'000, 16));
+    REQUIRE(0 == updateAnotherSession(2, 1'000'000, 16));
     REQUIRE(rxs_1.transfer_timestamp_usec == 20'000'300);
     REQUIRE(rxs_1.payload_size == 7);
     REQUIRE(0 == std::memcmp(rxs_1.payload, "\x06\x06\x06\x06\x06\x06\x06", 7));
     REQUIRE(rxs_1.calculated_crc == crc("\x06\x06\x06\x06\x06\x06\x06"));
     REQUIRE(rxs_1.transfer_id == 14U);
-    REQUIRE(rxs_1.redundant_transport_index == 1);
+    REQUIRE(rxs_1.redundant_transport_index == 2);
     REQUIRE(ins_1.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins_1.getAllocator().getTotalAllocatedAmount() == 16);
 
@@ -648,24 +648,24 @@ TEST_CASE("rxSessionUpdate")
     frame.frame_index       = 2;
     frame.payload_size      = 7;
     frame.payload           = reinterpret_cast<const uint8_t*>("\x07\x07\x07\x07\x07\x07\x07");
-    REQUIRE(0 == update(0, 1'000'000, 16));
+    REQUIRE(0 == update(1, 1'000'000, 16));
     REQUIRE(rxs.transfer_timestamp_usec == 20'000'300);
     REQUIRE(rxs.payload_size == 14);
     REQUIRE(0 == std::memcmp(rxs.payload, "\x06\x06\x06\x06\x06\x06\x06\x07\x07\x07\x07\x07\x07\x07", 14));
     REQUIRE(rxs.calculated_crc == crc("\x06\x06\x06\x06\x06\x06\x06\x07\x07\x07\x07\x07\x07\x07"));
     REQUIRE(rxs.transfer_id == 14U);
-    REQUIRE(rxs.redundant_transport_index == 0);
+    REQUIRE(rxs.redundant_transport_index == 1);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 16);
     
     // Update another session using same frame.
-    REQUIRE(0 == updateAnotherSession(1, 1'000'000, 16));
+    REQUIRE(0 == updateAnotherSession(2, 1'000'000, 16));
     REQUIRE(rxs_1.transfer_timestamp_usec == 20'000'300);
     REQUIRE(rxs_1.payload_size == 14);
     REQUIRE(0 == std::memcmp(rxs_1.payload, "\x06\x06\x06\x06\x06\x06\x06\x07\x07\x07\x07\x07\x07\x07", 14));
     REQUIRE(rxs_1.calculated_crc == crc("\x06\x06\x06\x06\x06\x06\x06\x07\x07\x07\x07\x07\x07\x07"));
     REQUIRE(rxs_1.transfer_id == 14U);
-    REQUIRE(rxs_1.redundant_transport_index == 1);
+    REQUIRE(rxs_1.redundant_transport_index == 2);
     REQUIRE(ins_1.getAllocator().getNumAllocatedFragments() == 1);
     REQUIRE(ins_1.getAllocator().getTotalAllocatedAmount() == 16);
     
@@ -675,13 +675,13 @@ TEST_CASE("rxSessionUpdate")
     frame.frame_index       = 3 + static_cast<uint32_t>(1U << static_cast<uint32_t>(31U));
     frame.payload_size      = 8;  // The payload is IMPLICITLY TRUNCATED, and the CRC IS STILL VALIDATED.
     frame.payload           = reinterpret_cast<const uint8_t*>("\x09\x09\x09\x09\x32\x98\x04\x7B");
-    REQUIRE(1 == update(0, 1'000'000, 16));
+    REQUIRE(1 == update(1, 1'000'000, 16));
     REQUIRE(rxs.transfer_timestamp_usec == 20'000'300);  // The timestamp is the same as the first frame.
     REQUIRE(rxs.payload_size == 0);
     REQUIRE(rxs.payload == nullptr);
     REQUIRE(rxs.calculated_crc == 0xFFFFFFFFU);
     REQUIRE(rxs.transfer_id == 15U);
-    REQUIRE(rxs.redundant_transport_index == 0);
+    REQUIRE(rxs.redundant_transport_index == 1);
     REQUIRE(transfer.timestamp_usec == 20'000'300);
     REQUIRE(transfer.metadata.priority == UdpardPrioritySlow);
     REQUIRE(transfer.metadata.transfer_kind == UdpardTransferKindMessage);
@@ -695,13 +695,13 @@ TEST_CASE("rxSessionUpdate")
     ins.getAllocator().deallocate(transfer.payload);
 
     // Update another session using same frame.
-    REQUIRE(1 == updateAnotherSession(1, 1'000'000, 16));
+    REQUIRE(1 == updateAnotherSession(2, 1'000'000, 16));
     REQUIRE(rxs_1.transfer_timestamp_usec == 20'000'300); // The timestamp is the same as the first frame.
     REQUIRE(rxs_1.payload_size == 0);
     REQUIRE(rxs_1.payload == nullptr);
     REQUIRE(rxs_1.calculated_crc == 0xFFFFFFFFU);
     REQUIRE(rxs_1.transfer_id == 15U);
-    REQUIRE(rxs_1.redundant_transport_index == 1);
+    REQUIRE(rxs_1.redundant_transport_index == 2);
     REQUIRE(transfer.timestamp_usec == 20'000'300);
     REQUIRE(transfer.metadata.priority == UdpardPrioritySlow);
     REQUIRE(transfer.metadata.transfer_kind == UdpardTransferKindMessage);
@@ -721,13 +721,13 @@ TEST_CASE("rxSessionUpdate")
     frame.end_of_transfer   = false;
     frame.payload_size      = 7;
     frame.payload           = reinterpret_cast<const uint8_t*>("\x0A\x0A\x0A\x0A\x0A\x0A\x0A");
-    REQUIRE(0 == update(2, 1'000'000, 16));
+    REQUIRE(0 == update(1, 1'000'000, 16));
     REQUIRE(rxs.transfer_timestamp_usec == 20'000'300);  // No change.
     REQUIRE(rxs.payload_size == 0);
     REQUIRE(rxs.payload == nullptr);
     REQUIRE(rxs.calculated_crc == 0xFFFFFFFFU);
     REQUIRE(rxs.transfer_id == 13U);
-    REQUIRE(rxs.redundant_transport_index == 2);
+    REQUIRE(rxs.redundant_transport_index == 1);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 0);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 0);
 
@@ -738,13 +738,13 @@ TEST_CASE("rxSessionUpdate")
     frame.end_of_transfer   = true;
     frame.payload_size      = 8;
     frame.payload           = reinterpret_cast<const uint8_t*>("\x0E\x0E\x0E\x0E\x0E\x0E\x0E\xF7");
-    REQUIRE((-UDPARD_ERROR_OUT_OF_MEMORY) == update(2, 1'000'000, 17));  // Exceeds the heap quota.
+    REQUIRE((-UDPARD_ERROR_OUT_OF_MEMORY) == update(1, 1'000'000, 17));  // Exceeds the heap quota.
     REQUIRE(rxs.transfer_timestamp_usec == 20'000'400);
     REQUIRE(rxs.payload_size == 0);
     REQUIRE(rxs.payload == nullptr);
     REQUIRE(rxs.calculated_crc == 0xFFFFFFFFU);
     REQUIRE(rxs.transfer_id == 31U);  // Reset.
-    REQUIRE(rxs.redundant_transport_index == 2);
+    REQUIRE(rxs.redundant_transport_index == 1);
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 0);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 0);
 }

--- a/tests/test_public_roundtrip.cpp
+++ b/tests/test_public_roundtrip.cpp
@@ -171,7 +171,7 @@ TEST_CASE("RoundtripSimple")
                 UdpardRxTransfer      transfer{};
                 UdpardRxSubscription* subscription = nullptr;
 
-                std::int8_t result = ins_rx.rxAccept(
+                std::int8_t result_transport_index_0 = ins_rx.rxAccept(
                     ti->tx_deadline_usec,
                     ti->frame,
                     0,
@@ -179,7 +179,17 @@ TEST_CASE("RoundtripSimple")
                     transfer,
                     &subscription);
 
-                if (result == 1)
+                std::int8_t result_transport_index_1 = ins_rx.rxAccept(
+                    ti->tx_deadline_usec,
+                    ti->frame,
+                    1,
+                    ti->specifier,
+                    transfer,
+                    &subscription);
+
+                REQUIRE(result_transport_index_1 == 0);
+
+                if (result_transport_index_0 == 1)
                 {
                     Pending reference{};  // Fetch the reference transfer from the list of pending.
                     {
@@ -213,7 +223,7 @@ TEST_CASE("RoundtripSimple")
                 }
                 else
                 {
-                    REQUIRE((result == 0 || result == -UDPARD_ERROR_OUT_OF_ORDER));
+                    REQUIRE(result_transport_index_0 == 0);
                 }
             }
             else


### PR DESCRIPTION
While updating the out-of-order multiframe bug, another bug was found related to using redundant transports. We were updating the RX session for multiframe transfers without verifying that the transport index passed into udpardRxAccept matched the index saved for the RX session.