### PR TITLE
Implement the RX pipeline

### DIFF
--- a/libudpard/_udpard_cavl.h
+++ b/libudpard/_udpard_cavl.h
@@ -47,7 +47,7 @@ typedef struct UdpardTreeNode Cavl;
 
 /// Returns POSITIVE if the search target is GREATER than the provided node, negative if smaller, zero on match (found).
 /// Values other than {-1, 0, +1} are not recommended to avoid overflow during the narrowing conversion of the result.
-typedef int8_t (*CavlPredicate)(void* user_reference, const Cavl* node);
+typedef int_fast8_t (*CavlPredicate)(void* user_reference, const Cavl* node);
 
 /// If provided, the factory will be invoked when the sought node does not exist in the tree.
 /// It is expected to return a new node that will be inserted immediately (without the need to traverse the tree again).
@@ -117,13 +117,13 @@ static inline void cavlPrivateRotate(Cavl* const x, const bool r)
 static inline Cavl* cavlPrivateAdjustBalance(Cavl* const x, const bool increment)
 {
     CAVL_ASSERT((x != NULL) && ((x->bf >= -1) && (x->bf <= +1)));
-    Cavl*        out    = x;
-    const int8_t new_bf = (int8_t) (x->bf + (increment ? +1 : -1));
+    Cavl*             out    = x;
+    const int_fast8_t new_bf = (int_fast8_t) (x->bf + (increment ? +1 : -1));
     if ((new_bf < -1) || (new_bf > 1))
     {
-        const bool   r    = new_bf < 0;   // bf<0 if left-heavy --> right rotation is needed.
-        const int8_t sign = r ? +1 : -1;  // Positive if we are rotating right.
-        Cavl* const  z    = x->lr[!r];
+        const bool        r    = new_bf < 0;   // bf<0 if left-heavy --> right rotation is needed.
+        const int_fast8_t sign = r ? +1 : -1;  // Positive if we are rotating right.
+        Cavl* const       z    = x->lr[!r];
         CAVL_ASSERT(z != NULL);  // Heavy side cannot be empty.
         // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
         if ((z->bf * sign) <= 0)  // Parent and child are heavy on the same side or the child is balanced.
@@ -132,8 +132,8 @@ static inline Cavl* cavlPrivateAdjustBalance(Cavl* const x, const bool increment
             cavlPrivateRotate(x, r);
             if (0 == z->bf)
             {
-                x->bf = (int8_t) (-sign);
-                z->bf = (int8_t) (+sign);
+                x->bf = (int_fast8_t) (-sign);
+                z->bf = (int_fast8_t) (+sign);
             }
             else
             {
@@ -150,7 +150,7 @@ static inline Cavl* cavlPrivateAdjustBalance(Cavl* const x, const bool increment
             cavlPrivateRotate(x, r);
             if ((y->bf * sign) < 0)
             {
-                x->bf = (int8_t) (+sign);
+                x->bf = (int_fast8_t) (+sign);
                 y->bf = 0;
                 z->bf = 0;
             }
@@ -158,7 +158,7 @@ static inline Cavl* cavlPrivateAdjustBalance(Cavl* const x, const bool increment
             {
                 x->bf = 0;
                 y->bf = 0;
-                z->bf = (int8_t) (-sign);
+                z->bf = (int_fast8_t) (-sign);
             }
             else
             {
@@ -209,7 +209,7 @@ static inline Cavl* cavlSearch(Cavl** const        root,
         Cavl** n  = root;
         while (*n != NULL)
         {
-            const int8_t cmp = predicate(user_reference, *n);
+            const int_fast8_t cmp = predicate(user_reference, *n);
             if (0 == cmp)
             {
                 out = *n;

--- a/libudpard/udpard.c
+++ b/libudpard/udpard.c
@@ -886,7 +886,7 @@ struct UdpardInternalRxSession
 
 /// Frees all fragments in the tree and their payload buffers. Destroys the passed fragment.
 /// This is meant to be invoked on the root of the tree.
-// NOLINTNEXTLINE(misc-no-recursion)
+// NOLINTNEXTLINE(misc-no-recursion) MISRA C:2012 rule 17.2
 static inline void rxFragmentDestroyTree(RxFragment* const self, const RxMemory memory)
 {
     UDPARD_ASSERT(self != NULL);
@@ -988,7 +988,7 @@ typedef struct
 } RxSlotEjectContext;
 
 /// See rxSlotEject() for details.
-/// NOLINTNEXTLINE(misc-no-recursion)
+/// NOLINTNEXTLINE(misc-no-recursion) MISRA C:2012 rule 17.2
 static inline void rxSlotEjectFragment(RxFragment* const frag, RxSlotEjectContext* const ctx)
 {
     UDPARD_ASSERT((frag != NULL) && (ctx != NULL));
@@ -1048,6 +1048,7 @@ static inline void rxSlotEjectFragment(RxFragment* const frag, RxSlotEjectContex
 /// There shall be at least one fragment (because a Cyphal transfer contains at least one frame).
 ///
 /// The return value indicates whether the transfer is valid (CRC is correct).
+/// This function performs ~log(n) of recursive calls internally, where n is the number of fragments.
 static inline bool rxSlotEject(size_t* const                out_payload_size,
                                struct UdpardFragment* const out_payload_head,
                                RxFragmentTreeNode* const    fragment_tree,
@@ -1413,7 +1414,7 @@ static inline void rxSessionInit(struct UdpardInternalRxSession* const self, con
 }
 
 /// Frees all ifaces in the session, all children in the session tree recursively, and destroys the session itself.
-// NOLINTNEXTLINE(*-no-recursion)
+// NOLINTNEXTLINE(*-no-recursion) MISRA C:2012 rule 17.2
 static inline void rxSessionDestroyTree(struct UdpardInternalRxSession* const self,
                                         const struct UdpardRxMemoryResources  memory)
 {

--- a/libudpard/udpard.c
+++ b/libudpard/udpard.c
@@ -327,8 +327,8 @@ static inline TxItem* txNewItem(struct UdpardMemoryResource* const memory,
 
 /// Frames with identical weight are processed in the FIFO order.
 /// Frames with higher weight compare smaller (i.e., put on the left side of the tree).
-static inline int8_t txAVLPredicate(void* const user_reference,  // NOSONAR Cavl API requires pointer to non-const.
-                                    const struct UdpardTreeNode* const node)
+static inline int_fast8_t txAVLPredicate(void* const user_reference,  // NOSONAR Cavl API requires pointer to non-const.
+                                         const struct UdpardTreeNode* const node)
 {
     const TxItem* const target = (const TxItem*) user_reference;
     const TxItem* const other  = (const TxItem*) (const void*) node;
@@ -528,12 +528,12 @@ static inline int32_t txPush(struct UdpardTx* const           tx,
     return out;
 }
 
-int8_t udpardTxInit(struct UdpardTx* const             self,
-                    const UdpardNodeID* const          local_node_id,
-                    const size_t                       queue_capacity,
-                    struct UdpardMemoryResource* const memory)
+int_fast8_t udpardTxInit(struct UdpardTx* const             self,
+                         const UdpardNodeID* const          local_node_id,
+                         const size_t                       queue_capacity,
+                         struct UdpardMemoryResource* const memory)
 {
-    int8_t ret = -UDPARD_ERROR_ARGUMENT;
+    int_fast8_t ret = -UDPARD_ERROR_ARGUMENT;
     if ((NULL != self) && (NULL != local_node_id) && memIsValid(memory))
     {
         ret = 0;
@@ -954,7 +954,7 @@ typedef struct
     struct UdpardMemoryResource* memory_fragment;
 } RxSlotUpdateContext;
 
-static inline int8_t rxSlotFragmentSearch(void* const user_reference, const struct UdpardTreeNode* node)
+static inline int_fast8_t rxSlotFragmentSearch(void* const user_reference, const struct UdpardTreeNode* node)
 {
     UDPARD_ASSERT((user_reference != NULL) && (node != NULL));
     return compare32(((const RxSlotUpdateContext*) user_reference)->frame_index,
@@ -1443,8 +1443,8 @@ typedef struct
     struct UdpardRxMemoryResources memory;
 } RxPortSessionSearchContext;
 
-static inline int8_t rxPortSessionSearch(void* const                  user_reference,  // NOSONAR non-const API
-                                         const struct UdpardTreeNode* node)
+static inline int_fast8_t rxPortSessionSearch(void* const                  user_reference,  // NOSONAR non-const API
+                                              const struct UdpardTreeNode* node)
 {
     UDPARD_ASSERT((user_reference != NULL) && (node != NULL));
     return compare32(((const RxPortSessionSearchContext*) user_reference)->remote_node_id,
@@ -1584,10 +1584,10 @@ void udpardFragmentFree(const struct UdpardFragment        head,
     }
 }
 
-int8_t udpardRxSubscriptionInit(struct UdpardRxSubscription* const   self,
-                                const UdpardPortID                   subject_id,
-                                const size_t                         extent,
-                                const struct UdpardRxMemoryResources memory)
+int_fast8_t udpardRxSubscriptionInit(struct UdpardRxSubscription* const   self,
+                                     const UdpardPortID                   subject_id,
+                                     const size_t                         extent,
+                                     const struct UdpardRxMemoryResources memory)
 {
     (void) self;
     (void) subject_id;

--- a/libudpard/udpard.c
+++ b/libudpard/udpard.c
@@ -822,6 +822,8 @@ static inline void rxFragmentFree(struct UdpardFragment* const head, const RxMem
 /// - Per interface, there are RX_SLOT_COUNT slots; a slot keeps the state of a transfer in the process of being
 ///   reassembled.
 ///
+/// Port -> Session -> Interface -> Slot.
+///
 /// Consider the following examples, where A and B denote distinct transfers of three frames each:
 ///
 ///     A0 A1 A2 B0 B1 B2  -- two transfers without OOO frames; both accepted.
@@ -872,6 +874,8 @@ typedef struct UdpardInternalRxSession
     /// at the speed of the fastest interface. Duplicate transfers delivered by the slower interfaces are discarded.
     RxIface ifaces[UDPARD_NETWORK_INTERFACE_COUNT_MAX];
 } UdpardInternalRxSession;
+
+// --------------------------------------------------  RX SLOT  --------------------------------------------------
 
 // NOLINTNEXTLINE(misc-no-recursion)
 static inline void rxSlotFree(RxFragment* const self, const RxMemory memory)
@@ -1152,6 +1156,8 @@ finish:
     return result;
 }
 
+// --------------------------------------------------  RX IFACE  --------------------------------------------------
+
 /// Whether the supplied transfer-ID is greater than all transfer-IDs in the RX slots.
 /// This indicates that the new transfer is not a duplicate and should be accepted.
 static inline bool rxIfaceIsFutureTransferID(const RxIface* const self, const UdpardTransferID transfer_id)
@@ -1301,6 +1307,8 @@ static inline void rxIfaceInit(RxIface* const self, const RxMemory memory)
     }
 }
 
+// --------------------------------------------------  RX SESSION  --------------------------------------------------
+
 /// Checks if the given transfer should be accepted. If not, the transfer is freed.
 /// Internal states are updated.
 static inline bool rxSessionDeduplicate(UdpardInternalRxSession* const self,
@@ -1368,6 +1376,12 @@ static inline void rxSessionInit(UdpardInternalRxSession* const self, const RxMe
         rxIfaceInit(&self->ifaces[i], memory);
     }
 }
+
+// --------------------------------------------------  RX PORT  --------------------------------------------------
+
+// TODO
+
+// --------------------------------------------------  RX API  --------------------------------------------------
 
 void udpardFragmentFree(const struct UdpardFragment        head,
                         struct UdpardMemoryResource* const memory_fragment,

--- a/libudpard/udpard.c
+++ b/libudpard/udpard.c
@@ -109,6 +109,21 @@ static inline uint32_t max32(const uint32_t a, const uint32_t b)
     return (a > b) ? a : b;
 }
 
+/// Returns the sign of the subtraction of the operands; zero if equal. This is useful for AVL search.
+static inline int_fast8_t compare32(const uint32_t a, const uint32_t b)
+{
+    int_fast8_t result = 0;
+    if (a > b)
+    {
+        result = +1;
+    }
+    if (a < b)
+    {
+        result = -1;
+    }
+    return result;
+}
+
 static inline bool memIsValid(const struct UdpardMemoryResource* const memory)
 {
     return (memory != NULL) && (memory->allocate != NULL) && (memory->free != NULL);
@@ -942,19 +957,8 @@ typedef struct
 static inline int8_t rxSlotFragmentSearch(void* const user_reference, const struct UdpardTreeNode* node)
 {
     UDPARD_ASSERT((user_reference != NULL) && (node != NULL));
-    const RxSlotUpdateContext* const ctx  = (RxSlotUpdateContext*) user_reference;
-    const RxFragment* const          frag = ((const RxFragmentTreeNode*) node)->this;
-    UDPARD_ASSERT((ctx != NULL) && (frag != NULL));
-    int8_t out = 0;
-    if (ctx->frame_index > frag->frame_index)
-    {
-        out = +1;
-    }
-    if (ctx->frame_index < frag->frame_index)
-    {
-        out = -1;
-    }
-    return out;
+    return compare32(((const RxSlotUpdateContext*) user_reference)->frame_index,
+                     ((const RxFragmentTreeNode*) node)->this->frame_index);
 }
 
 static inline struct UdpardTreeNode* rxSlotFragmentFactory(void* const user_reference)
@@ -1443,19 +1447,8 @@ static inline int8_t rxPortSessionSearch(void* const                  user_refer
                                          const struct UdpardTreeNode* node)
 {
     UDPARD_ASSERT((user_reference != NULL) && (node != NULL));
-    const RxPortSessionSearchContext* const     ctx     = (const RxPortSessionSearchContext*) user_reference;
-    const struct UdpardInternalRxSession* const session = (const struct UdpardInternalRxSession*) (const void*) node;
-    UDPARD_ASSERT((ctx != NULL) && (session != NULL));
-    int8_t out = 0;
-    if (ctx->remote_node_id > session->remote_node_id)
-    {
-        out = +1;
-    }
-    if (ctx->remote_node_id < session->remote_node_id)
-    {
-        out = -1;
-    }
-    return out;
+    return compare32(((const RxPortSessionSearchContext*) user_reference)->remote_node_id,
+                     ((const struct UdpardInternalRxSession*) (const void*) node)->remote_node_id);
 }
 
 static inline struct UdpardTreeNode* rxPortSessionFactory(void* const user_reference)  // NOSONAR non-const API

--- a/libudpard/udpard.c
+++ b/libudpard/udpard.c
@@ -352,7 +352,7 @@ static inline byte_t* txSerializeHeader(byte_t* const          destination_buffe
     ptr         = txSerializeU64(ptr, meta.transfer_id);
     UDPARD_ASSERT((frame_index + 0UL) <= HEADER_FRAME_INDEX_MAX);  // +0UL is to avoid a compiler warning.
     ptr = txSerializeU32(ptr, frame_index | (end_of_transfer ? HEADER_FRAME_INDEX_EOT_MASK : 0U));
-    ptr = txSerializeU16(ptr, 0);                                  // opaque user data
+    ptr = txSerializeU16(ptr, 0);  // opaque user data
     // Header CRC in the big endian format. Optimization prospect: the header up to frame_index is constant in
     // multi-frame transfers, so we don't really need to recompute the CRC from scratch per frame.
     const uint16_t crc = headerCRCCompute(HEADER_SIZE_BYTES - HEADER_CRC_SIZE_BYTES, destination_buffer);
@@ -752,7 +752,7 @@ static inline bool rxParseFrame(const struct UdpardMutablePayload datagram_paylo
         }
         // Parsers for other header versions may be added here later.
     }
-    if (ok)                                    // Version-agnostic semantics check.
+    if (ok)  // Version-agnostic semantics check.
     {
         UDPARD_ASSERT(out->payload.size > 0);  // Follows from the prior checks.
         const bool anonymous    = out->meta.src_node_id == UDPARD_NODE_ID_UNSET;
@@ -801,7 +801,7 @@ typedef struct RxFragment
 /// (this is possible because all common CRC functions are linear).
 typedef struct
 {
-    UdpardMicrosecond   ts_usec;    ///< Timestamp of the earliest frame; UINT64_MAX initially.
+    UdpardMicrosecond   ts_usec;  ///< Timestamp of the earliest frame; UINT64_MAX initially.
     UdpardTransferID    transfer_id;
     uint32_t            max_index;  ///< Maximum observed frame index in this transfer (so far); zero initially.
     uint32_t            eot_index;  ///< Frame index where the end-of-transfer flag was observed; UINT32_MAX initially.
@@ -901,10 +901,11 @@ static inline struct UdpardTreeNode* rxSessionSlotFragmentFactory(void* const us
     RxFragment* const      frag = memAlloc(ctx->memory_payload_fragment_handle, sizeof(RxFragment));
     if (frag != NULL)
     {
+        // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
         (void) memset(frag, 0, sizeof(RxFragment));
         out               = &frag->tree.base;  // this is not an escape bug, we retain the pointer via "this"
         frag->frame_index = ctx->frame_index;
-        frag->tree.this   = frag;              // <-- right here, see?
+        frag->tree.this   = frag;  // <-- right here, see?
         ctx->accepted     = true;
     }
     return out;  // OOM handled by the caller
@@ -965,6 +966,7 @@ static inline void rxSessionSlotEject(RxFragment* const frag, RxSessionSlotEject
     {
         rxSessionSlotEject(((RxFragmentTreeNode*) frag->tree.base.lr[1])->this, ctx);
     }
+    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
     (void) memset(&frag->tree.base, 0, sizeof(struct UdpardTreeNode));  // Avoid dangling pointers.
     // Drop the unneeded fragments and their handles after the sub-tree is fully traversed.
     if ((!retain) || (frag->base.view.size == 0))
@@ -1149,7 +1151,7 @@ static inline int_fast8_t rxSessionIfaceUpdate(RxSessionIface* const            
     {
         if (slot->ts_usec == UINT64_MAX)
         {
-            slot->ts_usec = ts_usec;        // Transfer timestamp is the timestamp of the earliest frame.
+            slot->ts_usec = ts_usec;  // Transfer timestamp is the timestamp of the earliest frame.
         }
         result = rxSessionSlotUpdate(slot,  // Takes ownership of the frame payload; may free or keep it.
                                      frame,

--- a/libudpard/udpard.c
+++ b/libudpard/udpard.c
@@ -886,6 +886,7 @@ struct UdpardInternalRxSession
 
 /// Frees all fragments in the tree and their payload buffers. Destroys the passed fragment.
 /// This is meant to be invoked on the root of the tree.
+/// The maximum recursion depth is ceil(1.44*log2(FRAME_INDEX_MAX+1)-0.328) = 22 levels.
 // NOLINTNEXTLINE(misc-no-recursion) MISRA C:2012 rule 17.2
 static inline void rxFragmentDestroyTree(RxFragment* const self, const RxMemory memory)
 {
@@ -988,6 +989,7 @@ typedef struct
 } RxSlotEjectContext;
 
 /// See rxSlotEject() for details.
+/// The maximum recursion depth is ceil(1.44*log2(FRAME_INDEX_MAX+1)-0.328) = 22 levels.
 /// NOLINTNEXTLINE(misc-no-recursion) MISRA C:2012 rule 17.2
 static inline void rxSlotEjectFragment(RxFragment* const frag, RxSlotEjectContext* const ctx)
 {
@@ -1048,7 +1050,6 @@ static inline void rxSlotEjectFragment(RxFragment* const frag, RxSlotEjectContex
 /// There shall be at least one fragment (because a Cyphal transfer contains at least one frame).
 ///
 /// The return value indicates whether the transfer is valid (CRC is correct).
-/// This function performs ~log(n) of recursive calls internally, where n is the number of fragments.
 static inline bool rxSlotEject(size_t* const                out_payload_size,
                                struct UdpardFragment* const out_payload_head,
                                RxFragmentTreeNode* const    fragment_tree,
@@ -1414,6 +1415,7 @@ static inline void rxSessionInit(struct UdpardInternalRxSession* const self, con
 }
 
 /// Frees all ifaces in the session, all children in the session tree recursively, and destroys the session itself.
+/// The maximum recursion depth is ceil(1.44*log2(UDPARD_NODE_ID_MAX+1)-0.328) = 23 levels.
 // NOLINTNEXTLINE(*-no-recursion) MISRA C:2012 rule 17.2
 static inline void rxSessionDestroyTree(struct UdpardInternalRxSession* const self,
                                         const struct UdpardRxMemoryResources  memory)

--- a/libudpard/udpard.c
+++ b/libudpard/udpard.c
@@ -866,7 +866,7 @@ typedef struct
 /// This type is forward-declared externally, hence why it has such a long name with the "udpard" prefix.
 /// Keep in mind that we have a dedicated session object per remote node per port; this means that the states
 /// kept here -- the timestamp and the transfer-ID -- are specific per remote node, as it should be.
-typedef struct UdpardInternalRxSession
+struct UdpardInternalRxSession
 {
     struct UdpardTreeNode base;
     /// The remote node-ID is needed here as this is the ordering/search key.
@@ -880,7 +880,7 @@ typedef struct UdpardInternalRxSession
     /// The first interface to receive a transfer takes precedence, thus the redundant group always operates
     /// at the speed of the fastest interface. Duplicate transfers delivered by the slower interfaces are discarded.
     RxIface ifaces[UDPARD_NETWORK_INTERFACE_COUNT_MAX];
-} UdpardInternalRxSession;
+};
 
 // --------------------------------------------------  RX FRAGMENT  --------------------------------------------------
 
@@ -1342,10 +1342,10 @@ static inline void rxIfaceFree(RxIface* const self, const RxMemory memory)
 
 /// Checks if the given transfer should be accepted. If not, the transfer is freed.
 /// Internal states are updated.
-static inline bool rxSessionDeduplicate(UdpardInternalRxSession* const self,
-                                        const UdpardMicrosecond        transfer_id_timeout_usec,
-                                        struct UdpardRxTransfer* const transfer,
-                                        const RxMemory                 memory)
+static inline bool rxSessionDeduplicate(struct UdpardInternalRxSession* const self,
+                                        const UdpardMicrosecond               transfer_id_timeout_usec,
+                                        struct UdpardRxTransfer* const        transfer,
+                                        const RxMemory                        memory)
 {
     UDPARD_ASSERT((self != NULL) && (transfer != NULL));
     const bool future_tid = (self->last_transfer_id == TRANSFER_ID_UNSET) ||  //
@@ -1372,14 +1372,14 @@ static inline bool rxSessionDeduplicate(UdpardInternalRxSession* const self,
 }
 
 /// Takes ownership of the frame payload buffer.
-static inline int_fast8_t rxSessionAccept(UdpardInternalRxSession* const self,
-                                          const uint_fast8_t             redundant_iface_index,
-                                          const UdpardMicrosecond        ts_usec,
-                                          const RxFrame                  frame,
-                                          const size_t                   extent,
-                                          const UdpardMicrosecond        transfer_id_timeout_usec,
-                                          const RxMemory                 memory,
-                                          struct UdpardRxTransfer* const out_transfer)
+static inline int_fast8_t rxSessionAccept(struct UdpardInternalRxSession* const self,
+                                          const uint_fast8_t                    redundant_iface_index,
+                                          const UdpardMicrosecond               ts_usec,
+                                          const RxFrame                         frame,
+                                          const size_t                          extent,
+                                          const UdpardMicrosecond               transfer_id_timeout_usec,
+                                          const RxMemory                        memory,
+                                          struct UdpardRxTransfer* const        out_transfer)
 {
     UDPARD_ASSERT((self != NULL) && (redundant_iface_index < UDPARD_NETWORK_INTERFACE_COUNT_MAX) &&
                   (out_transfer != NULL));
@@ -1398,7 +1398,7 @@ static inline int_fast8_t rxSessionAccept(UdpardInternalRxSession* const self,
     return result;
 }
 
-static inline void rxSessionInit(UdpardInternalRxSession* const self, const RxMemory memory)
+static inline void rxSessionInit(struct UdpardInternalRxSession* const self, const RxMemory memory)
 {
     UDPARD_ASSERT(self != NULL);
     memZero(sizeof(*self), self);
@@ -1413,8 +1413,8 @@ static inline void rxSessionInit(UdpardInternalRxSession* const self, const RxMe
 
 /// Frees all ifaces in the session, all children in the session tree recursively, and destroys the session itself.
 // NOLINTNEXTLINE(*-no-recursion)
-static inline void rxSessionDestroyTree(UdpardInternalRxSession* const       self,
-                                        const struct UdpardRxMemoryResources memory)
+static inline void rxSessionDestroyTree(struct UdpardInternalRxSession* const self,
+                                        const struct UdpardRxMemoryResources  memory)
 {
     for (uint_fast8_t i = 0; i < UDPARD_NETWORK_INTERFACE_COUNT_MAX; i++)
     {
@@ -1422,14 +1422,14 @@ static inline void rxSessionDestroyTree(UdpardInternalRxSession* const       sel
     }
     for (uint_fast8_t i = 0; i < 2; i++)
     {
-        UdpardInternalRxSession* const child = (UdpardInternalRxSession*) (void*) self->base.lr[i];
+        struct UdpardInternalRxSession* const child = (struct UdpardInternalRxSession*) (void*) self->base.lr[i];
         if (child != NULL)
         {
             UDPARD_ASSERT(child->base.up == &self->base);
             rxSessionDestroyTree(child, memory);  // NOSONAR recursion
         }
     }
-    memFree(memory.session, sizeof(UdpardInternalRxSession), self);
+    memFree(memory.session, sizeof(struct UdpardInternalRxSession), self);
 }
 
 // --------------------------------------------------  RX PORT  --------------------------------------------------

--- a/libudpard/udpard.c
+++ b/libudpard/udpard.c
@@ -132,14 +132,14 @@ static inline void* memAlloc(const struct UdpardMemoryResource memory, const siz
 
 static inline void memFree(const struct UdpardMemoryResource memory, const size_t size, void* const data)
 {
-    UDPARD_ASSERT(memory.free != NULL);
-    memory.free(memory.user_reference, size, data);
+    UDPARD_ASSERT(memory.deallocate != NULL);
+    memory.deallocate(memory.user_reference, size, data);
 }
 
 static inline void memFreePayload(const struct UdpardMemoryDeleter memory, const struct UdpardMutablePayload payload)
 {
-    UDPARD_ASSERT(memory.free != NULL);
-    memory.free(memory.user_reference, payload.size, payload.data);
+    UDPARD_ASSERT(memory.deallocate != NULL);
+    memory.deallocate(memory.user_reference, payload.size, payload.data);
 }
 
 static inline void memZero(const size_t size, void* const data)
@@ -528,7 +528,7 @@ int_fast8_t udpardTxInit(struct UdpardTx* const            self,
                          const struct UdpardMemoryResource memory)
 {
     int_fast8_t ret = -UDPARD_ERROR_ARGUMENT;
-    if ((NULL != self) && (NULL != local_node_id) && (memory.allocate != NULL) && (memory.free != NULL))
+    if ((NULL != self) && (NULL != local_node_id) && (memory.allocate != NULL) && (memory.deallocate != NULL))
     {
         ret = 0;
         memZero(sizeof(*self), self);
@@ -961,7 +961,8 @@ static inline int_fast8_t rxSlotFragmentSearch(void* const user_reference,  // N
 static inline struct UdpardTreeNode* rxSlotFragmentFactory(void* const user_reference)
 {
     RxSlotUpdateContext* const ctx = (RxSlotUpdateContext*) user_reference;
-    UDPARD_ASSERT((ctx != NULL) && (ctx->memory_fragment.allocate != NULL) && (ctx->memory_fragment.free != NULL));
+    UDPARD_ASSERT((ctx != NULL) && (ctx->memory_fragment.allocate != NULL) &&
+                  (ctx->memory_fragment.deallocate != NULL));
     struct UdpardTreeNode* out  = NULL;
     RxFragment* const      frag = memAlloc(ctx->memory_fragment, sizeof(RxFragment));
     if (frag != NULL)

--- a/libudpard/udpard.c
+++ b/libudpard/udpard.c
@@ -747,10 +747,10 @@ static inline bool rxParseFrame(const struct UdpardMutablePayload datagram_paylo
         if ((datagram_payload.size > HEADER_SIZE_BYTES) && (version == HEADER_VERSION) &&
             (headerCRCCompute(HEADER_SIZE_BYTES, datagram_payload.data) == HEADER_CRC_RESIDUE))
         {
-            const uint_fast8_t prio = *ptr++;
-            if (prio <= UDPARD_PRIORITY_MAX)
+            const uint_fast8_t priority = *ptr++;
+            if (priority <= UDPARD_PRIORITY_MAX)
             {
-                out->meta.priority        = (enum UdpardPriority) prio;
+                out->meta.priority        = (enum UdpardPriority) priority;
                 ptr                       = txDeserializeU16(ptr, &out->meta.src_node_id);
                 ptr                       = txDeserializeU16(ptr, &out->meta.dst_node_id);
                 ptr                       = txDeserializeU16(ptr, &out->meta.data_specifier);

--- a/libudpard/udpard.c
+++ b/libudpard/udpard.c
@@ -1419,7 +1419,7 @@ static inline void rxSessionDestroyTree(UdpardInternalRxSession* const       sel
     }
     for (uint_fast8_t i = 0; i < 2; i++)
     {
-        UdpardInternalRxSession* const child = (UdpardInternalRxSession*) self->base.lr[i];
+        UdpardInternalRxSession* const child = (UdpardInternalRxSession*) (void*) self->base.lr[i];
         if (child != NULL)
         {
             UDPARD_ASSERT(child->base.up == &self->base);

--- a/libudpard/udpard.c
+++ b/libudpard/udpard.c
@@ -954,7 +954,8 @@ typedef struct
     struct UdpardMemoryResource* memory_fragment;
 } RxSlotUpdateContext;
 
-static inline int_fast8_t rxSlotFragmentSearch(void* const user_reference, const struct UdpardTreeNode* node)
+static inline int_fast8_t rxSlotFragmentSearch(void* const user_reference,  // NOSONAR Cavl API requires non-const.
+                                               const struct UdpardTreeNode* node)
 {
     UDPARD_ASSERT((user_reference != NULL) && (node != NULL));
     return compare32(((const RxSlotUpdateContext*) user_reference)->frame_index,

--- a/libudpard/udpard.c
+++ b/libudpard/udpard.c
@@ -1574,9 +1574,9 @@ static inline void rxPortFree(struct UdpardRxPort* const self, const struct Udpa
 
 // --------------------------------------------------  RX API  --------------------------------------------------
 
-void udpardFragmentFree(const struct UdpardFragment        head,
-                        struct UdpardMemoryResource* const memory_fragment,
-                        struct UdpardMemoryResource* const memory_payload)
+void udpardRxFragmentFree(const struct UdpardFragment        head,
+                          struct UdpardMemoryResource* const memory_fragment,
+                          struct UdpardMemoryResource* const memory_payload)
 {
     if ((memory_fragment != NULL) && (memory_payload != NULL))  // The head is not heap-allocated so not freed.
     {

--- a/libudpard/udpard.c
+++ b/libudpard/udpard.c
@@ -1098,7 +1098,7 @@ static inline bool rxSlotEject(size_t* const                out_payload_size,
 
 /// Update the frame count discovery state in this transfer.
 /// Returns true on success, false if inconsistencies are detected and the slot should be restarted.
-static inline bool rxSlotAccept_UpdateFrameCountDiscovery(RxSlot* const self, const RxFrameBase frame)
+static inline bool rxSlotAccept_UpdateFrameCount(RxSlot* const self, const RxFrameBase frame)
 {
     UDPARD_ASSERT((self != NULL) && (frame.payload.size > 0));
     bool ok         = true;
@@ -1199,7 +1199,7 @@ static inline int_fast8_t rxSlotAccept(RxSlot* const                self,
                   (out_transfer_payload_head != NULL));
     int_fast8_t result  = 0;
     bool        release = true;
-    if (rxSlotAccept_UpdateFrameCountDiscovery(self, frame))
+    if (rxSlotAccept_UpdateFrameCount(self, frame))
     {
         result = rxSlotAccept_InsertFragment(self, frame, memory);
         UDPARD_ASSERT(result <= 1);

--- a/libudpard/udpard.c
+++ b/libudpard/udpard.c
@@ -1116,6 +1116,7 @@ static inline int_fast8_t rxSlotAccept(RxSlot* const                      self,
         frag->this->base.view   = frame.payload;
         frag->this->base.origin = frame.origin;
         self->payload_size += frame.payload.size;
+        self->accepted_frames++;
         release = false;  // Ownership of the payload buffer has been transferred to the fragment tree.
     }
     // THIRD: Detect transfer completion. If complete, eject the payload from the fragment tree and check its CRC.

--- a/libudpard/udpard.h
+++ b/libudpard/udpard.h
@@ -852,6 +852,8 @@ void udpardRxSubscriptionDestroy(struct UdpardRxSubscription* const self);
 /// The time complexity is O(log n) where n is the number of remote notes publishing on this subject (topic).
 /// No data copy takes place. Malformed frames are discarded in constant time.
 ///
+/// This function performs log(n) of recursive calls internally, where n is the number of frames in a transfer.
+///
 /// UDPARD_ERROR_MEMORY is returned if the function fails to allocate memory.
 /// UDPARD_ERROR_ARGUMENT is returned if any of the input arguments are invalid.
 int8_t udpardRxSubscriptionReceive(struct UdpardRxSubscription* const self,

--- a/libudpard/udpard.h
+++ b/libudpard/udpard.h
@@ -265,7 +265,7 @@ struct UdpardTreeNode
 {
     struct UdpardTreeNode* up;     ///< Do not access this field.
     struct UdpardTreeNode* lr[2];  ///< Left and right children of this node may be accessed for tree traversal.
-    int8_t                 bf;     ///< Do not access this field.
+    int_fast8_t            bf;     ///< Do not access this field.
 };
 
 struct UdpardMutablePayload
@@ -474,10 +474,10 @@ struct UdpardTxItem
 /// To safely discard it, simply pop all enqueued frames from it.
 ///
 /// The time complexity is constant. This function does not invoke the dynamic memory manager.
-int8_t udpardTxInit(struct UdpardTx* const             self,
-                    const UdpardNodeID* const          local_node_id,
-                    const size_t                       queue_capacity,
-                    struct UdpardMemoryResource* const memory);
+int_fast8_t udpardTxInit(struct UdpardTx* const             self,
+                         const UdpardNodeID* const          local_node_id,
+                         const size_t                       queue_capacity,
+                         struct UdpardMemoryResource* const memory);
 
 /// This function serializes a message transfer into a sequence of UDP datagrams and inserts them into the prioritized
 /// transmission queue at the appropriate position. Afterwards, the application is supposed to take the enqueued frames
@@ -804,10 +804,10 @@ struct UdpardRxSubscription
 /// The return value is a negated UDPARD_ERROR_ARGUMENT if any of the input arguments are invalid.
 ///
 /// The time complexity is constant. This function does not invoke the dynamic memory manager.
-int8_t udpardRxSubscriptionInit(struct UdpardRxSubscription* const   self,
-                                const UdpardPortID                   subject_id,
-                                const size_t                         extent,
-                                const struct UdpardRxMemoryResources memory);
+int_fast8_t udpardRxSubscriptionInit(struct UdpardRxSubscription* const   self,
+                                     const UdpardPortID                   subject_id,
+                                     const size_t                         extent,
+                                     const struct UdpardRxMemoryResources memory);
 
 /// Frees all memory held by the subscription instance.
 /// After invoking this function, the instance is no longer usable.
@@ -862,11 +862,11 @@ void udpardRxSubscriptionFree(struct UdpardRxSubscription* const self);
 ///
 /// UDPARD_ERROR_MEMORY is returned if the function fails to allocate memory.
 /// UDPARD_ERROR_ARGUMENT is returned if any of the input arguments are invalid.
-int8_t udpardRxSubscriptionReceive(struct UdpardRxSubscription* const self,
-                                   const UdpardMicrosecond            timestamp_usec,
-                                   const struct UdpardMutablePayload  datagram_payload,
-                                   const uint_fast8_t                 redundant_iface_index,
-                                   struct UdpardRxTransfer* const     out_transfer);
+int_fast8_t udpardRxSubscriptionReceive(struct UdpardRxSubscription* const self,
+                                        const UdpardMicrosecond            timestamp_usec,
+                                        const struct UdpardMutablePayload  datagram_payload,
+                                        const uint_fast8_t                 redundant_iface_index,
+                                        struct UdpardRxTransfer* const     out_transfer);
 
 // ---------------------------------------------  RPC-SERVICES  ---------------------------------------------
 
@@ -947,9 +947,9 @@ struct UdpardRxRPCTransfer
 /// The return value is a negated UDPARD_ERROR_ARGUMENT if any of the input arguments are invalid.
 ///
 /// The time complexity is constant. This function does not invoke the dynamic memory manager.
-int8_t udpardRxRPCDispatcherInit(struct UdpardRxRPCDispatcher* const  self,
-                                 const UdpardNodeID                   local_node_id,
-                                 const struct UdpardRxMemoryResources memory);
+int_fast8_t udpardRxRPCDispatcherInit(struct UdpardRxRPCDispatcher* const  self,
+                                      const UdpardNodeID                   local_node_id,
+                                      const struct UdpardRxMemoryResources memory);
 
 /// Frees all memory held by the RPC-service dispatcher instance.
 /// After invoking this function, the instance is no longer usable.
@@ -977,11 +977,11 @@ void udpardRxRPCDispatcherFree(struct UdpardRxRPCDispatcher* const self);
 /// (request or response).
 /// This function does not allocate new memory. The function may deallocate memory if such registration already
 /// existed; the deallocation behavior is specified in the documentation for udpardRxRPCDispatcherCancel.
-int8_t udpardRxRPCDispatcherListen(struct UdpardRxRPCDispatcher* const self,
-                                   struct UdpardRxRPC* const           service,
-                                   const UdpardPortID                  service_id,
-                                   const bool                          is_request,
-                                   const size_t                        extent);
+int_fast8_t udpardRxRPCDispatcherListen(struct UdpardRxRPCDispatcher* const self,
+                                        struct UdpardRxRPC* const           service,
+                                        const UdpardPortID                  service_id,
+                                        const bool                          is_request,
+                                        const size_t                        extent);
 
 /// This function reverses the effect of udpardRxRPCDispatcherListen.
 /// If the registration is found, all its memory is de-allocated (session states and payload buffers).
@@ -993,19 +993,19 @@ int8_t udpardRxRPCDispatcherListen(struct UdpardRxRPCDispatcher* const self,
 ///
 /// The time complexity is logarithmic from the number of current registration under the specified transfer kind.
 /// This function does not allocate new memory.
-int8_t udpardRxRPCDispatcherCancel(struct UdpardRxRPCDispatcher* const self,
-                                   const UdpardPortID                  service_id,
-                                   const bool                          is_request);
+int_fast8_t udpardRxRPCDispatcherCancel(struct UdpardRxRPCDispatcher* const self,
+                                        const UdpardPortID                  service_id,
+                                        const bool                          is_request);
 
 /// Datagrams received from the sockets of this service dispatcher are fed into this function.
 /// It is the analog of udpardRxSubscriptionReceive for RPC-service transfers.
 /// Please refer to the documentation of udpardRxSubscriptionReceive for the usage information.
-int8_t udpardRxRPCDispatcherReceive(struct UdpardRxRPCDispatcher* const self,
-                                    struct UdpardRxRPC** const          service,
-                                    const UdpardMicrosecond             timestamp_usec,
-                                    const struct UdpardMutablePayload   datagram_payload,
-                                    const uint_fast8_t                  redundant_iface_index,
-                                    struct UdpardRxRPCTransfer* const   out_transfer);
+int_fast8_t udpardRxRPCDispatcherReceive(struct UdpardRxRPCDispatcher* const self,
+                                         struct UdpardRxRPC** const          service,
+                                         const UdpardMicrosecond             timestamp_usec,
+                                         const struct UdpardMutablePayload   datagram_payload,
+                                         const uint_fast8_t                  redundant_iface_index,
+                                         struct UdpardRxRPCTransfer* const   out_transfer);
 
 #ifdef __cplusplus
 }

--- a/libudpard/udpard.h
+++ b/libudpard/udpard.h
@@ -331,14 +331,15 @@ struct UdpardUDPIPEndpoint
 /// consider using O1Heap: https://github.com/pavel-kirienko/o1heap. Alternatively, some applications may prefer to
 /// use a set of fixed-size block pool allocators (see the high-level overview for details).
 ///
-/// The time complexity models given in the API documentation are made on the assumption that the memory management
-/// functions have constant complexity O(1).
+/// The API documentation is written on the assumption that the memory management functions have constant
+/// complexity and are non-blocking.
 ///
 /// The value of the user reference is taken from the corresponding field of the memory resource structure.
 typedef void* (*UdpardMemoryAllocate)(void* const user_reference, const size_t size);
 
 /// The counterpart of the above -- this function is invoked to return previously allocated memory to the allocator.
-/// The size argument contains the amount of memory that was originally requested via the allocation function.
+/// The size argument contains the amount of memory that was originally requested via the allocation function;
+/// its value is undefined if the pointer is NULL.
 /// The semantics are similar to free():
 ///     - The pointer was previously returned by the allocation function.
 ///     - The pointer may be NULL, in which case the function shall have no effect.

--- a/libudpard/udpard.h
+++ b/libudpard/udpard.h
@@ -286,9 +286,9 @@ struct UdpardPayload
 /// The model is as follows:
 ///
 ///     (payload header) ---> UdpardFragment:
-///                               next  ---> UdpardFragment...
-///                               owner ---> (the free()able payload data buffer)
-///                               view  ---> (somewhere inside the payload data buffer)
+///                               next   ---> UdpardFragment...
+///                               origin ---> (the free()able payload data buffer)
+///                               view   ---> (somewhere inside the payload data buffer)
 ///
 /// Payloads of received transfers are represented using this type, where each fragment corresponds to a frame.
 /// The application can either consume them directly or to copy the data into a contiguous buffer beforehand
@@ -745,9 +745,9 @@ struct UdpardRxTransfer
 /// design, where the head is stored by value to reduce indirection in small transfers. We call it Scott's Head.
 ///
 /// If any of the arguments are NULL, the function has no effect.
-void udpardFragmentFree(const struct UdpardFragment        head,
-                        struct UdpardMemoryResource* const memory_fragment,
-                        struct UdpardMemoryResource* const memory_payload);
+void udpardRxFragmentFree(const struct UdpardFragment        head,
+                          struct UdpardMemoryResource* const memory_fragment,
+                          struct UdpardMemoryResource* const memory_payload);
 
 // ---------------------------------------------  SUBJECTS  ---------------------------------------------
 

--- a/libudpard/udpard.h
+++ b/libudpard/udpard.h
@@ -809,7 +809,7 @@ int8_t udpardRxSubscriptionInit(struct UdpardRxSubscription* const   self,
 /// Frees all memory held by the subscription instance.
 /// After invoking this function, the instance is no longer usable.
 /// Do not forget to close the sockets that were opened for this subscription.
-void udpardRxSubscriptionDestroy(struct UdpardRxSubscription* const self);
+void udpardRxSubscriptionFree(struct UdpardRxSubscription* const self);
 
 /// Datagrams received from the sockets of this subscription are fed into this function.
 ///
@@ -951,7 +951,7 @@ int8_t udpardRxRPCDispatcherInit(struct UdpardRxRPCDispatcher* const  self,
 /// Frees all memory held by the RPC-service dispatcher instance.
 /// After invoking this function, the instance is no longer usable.
 /// Do not forget to close the sockets that were opened for this instance.
-void udpardRxRPCDispatcherDestroy(struct UdpardRxRPCDispatcher* const self);
+void udpardRxRPCDispatcherFree(struct UdpardRxRPCDispatcher* const self);
 
 /// This function lets the application register its interest in a particular service-ID and kind (request/response)
 /// by creating an RPC-service RX port. The service pointer shall retain validity until its unregistration or until

--- a/libudpard/udpard.h
+++ b/libudpard/udpard.h
@@ -71,6 +71,9 @@
 /// As will be shown below, a typical application with R redundant network interfaces and S topic subscriptions needs
 /// R*(S+2) sockets (or equivalent abstractions provided by the underlying UDP/IP stack).
 ///
+/// As a matter of convention, resource disposal functions are named "free" if the memory of the resource itself is
+/// not deallocated, and "destroy" if the memory is deallocated.
+///
 ///
 ///     Transmission pipeline
 ///

--- a/libudpard/udpard.h
+++ b/libudpard/udpard.h
@@ -302,7 +302,7 @@ struct UdpardPayloadFragmentHandle
     /// This entity points to the base buffer that contains this fragment.
     /// The application can use this pointer to free the outer buffer after the payload has been consumed.
     /// In the most simple case this field is identical to the "view" field above, but it is not always the case.
-    struct UdpardMutablePayload owner;
+    struct UdpardMutablePayload origin;
 };
 
 /// Cyphal/UDP uses only multicast traffic.
@@ -822,7 +822,8 @@ void udpardRxSubscriptionDestroy(struct UdpardRxSubscription* const self);
 ///
 /// The function takes ownership of the passed datagram payload buffer. The library will either store it as a
 /// fragment of the reassembled transfer payload or free it using the corresponding memory resource
-/// (see UdpardRxMemoryResources) if the datagram is not needed for reassembly.
+/// (see UdpardRxMemoryResources) if the datagram is not needed for reassembly. Because of the ownership transfer,
+/// the datagram payload buffer has to be mutable (non-const).
 ///
 /// The accepted datagram may either be invalid, carry a non-final part of a multi-frame transfer,
 /// carry a final part of a valid multi-frame transfer, or carry a valid single-frame transfer.
@@ -855,7 +856,7 @@ void udpardRxSubscriptionDestroy(struct UdpardRxSubscription* const self);
 /// UDPARD_ERROR_ARGUMENT is returned if any of the input arguments are invalid.
 int8_t udpardRxSubscriptionReceive(struct UdpardRxSubscription* const self,
                                    const UdpardMicrosecond            timestamp_usec,
-                                   const struct UdpardConstPayload    datagram_payload,
+                                   const struct UdpardMutablePayload  datagram_payload,
                                    const uint_fast8_t                 redundant_iface_index,
                                    struct UdpardRxTransfer* const     received_transfer);
 
@@ -991,7 +992,7 @@ int8_t udpardRxRPCDispatcherCancel(struct UdpardRxRPCDispatcher* const self,
 int8_t udpardRxRPCDispatcherReceive(struct UdpardRxRPCDispatcher* const self,
                                     struct UdpardRxRPC** const          service,
                                     const UdpardMicrosecond             timestamp_usec,
-                                    const struct UdpardConstPayload     datagram_payload,
+                                    const struct UdpardMutablePayload   datagram_payload,
                                     const uint_fast8_t                  redundant_iface_index,
                                     struct UdpardRxRPCTransfer* const   received_transfer);
 

--- a/libudpard/udpard.h
+++ b/libudpard/udpard.h
@@ -834,12 +834,13 @@ void udpardRxSubscriptionDestroy(struct UdpardRxSubscription* const self);
 /// carry a final part of a valid multi-frame transfer, or carry a valid single-frame transfer.
 /// The last two cases are said to complete a transfer.
 ///
-/// If the datagram completes a transfer, the received_transfer argument is filled with the transfer details
+/// If the datagram completes a transfer, the out_transfer argument is filled with the transfer details
 /// and the return value is one.
 /// The caller is assigned ownership of the transfer payload buffer memory; it has to be freed after use as described
 /// in the documentation for UdpardRxTransfer.
+/// The memory pointed to by out_transfer may be mutated arbitrarily if no transfer is completed.
 ///
-/// If the datagram does not complete a transfer or is malformed, the function returns zero and the received_transfer
+/// If the datagram does not complete a transfer or is malformed, the function returns zero and the out_transfer
 /// is not modified. Observe that malformed frames are not treated as errors, as the local application is not
 /// responsible for the behavior of external agents producing the datagrams.
 ///
@@ -866,7 +867,7 @@ int8_t udpardRxSubscriptionReceive(struct UdpardRxSubscription* const self,
                                    const UdpardMicrosecond            timestamp_usec,
                                    const struct UdpardMutablePayload  datagram_payload,
                                    const uint_fast8_t                 redundant_iface_index,
-                                   struct UdpardRxTransfer* const     received_transfer);
+                                   struct UdpardRxTransfer* const     out_transfer);
 
 // ---------------------------------------------  RPC-SERVICES  ---------------------------------------------
 
@@ -1002,7 +1003,7 @@ int8_t udpardRxRPCDispatcherReceive(struct UdpardRxRPCDispatcher* const self,
                                     const UdpardMicrosecond             timestamp_usec,
                                     const struct UdpardMutablePayload   datagram_payload,
                                     const uint_fast8_t                  redundant_iface_index,
-                                    struct UdpardRxRPCTransfer* const   received_transfer);
+                                    struct UdpardRxRPCTransfer* const   out_transfer);
 
 #ifdef __cplusplus
 }

--- a/libudpard/udpard.h
+++ b/libudpard/udpard.h
@@ -732,6 +732,8 @@ struct UdpardRxTransfer
     /// this requires freeing both the handles and the payload buffers they point to.
     /// Beware that different memory resources may have been used to allocate the handles and the payload buffers;
     /// the application is responsible for freeing them using the correct memory resource.
+    ///
+    /// If the payload is empty, the corresponding buffer pointers may be NULL.
     size_t                             payload_size;
     struct UdpardPayloadFragmentHandle payload;
 };

--- a/libudpard/udpard.h
+++ b/libudpard/udpard.h
@@ -626,10 +626,6 @@ void udpardTxFree(struct UdpardMemoryResource* const memory, struct UdpardTxItem
 /// redundant network interfaces.
 struct UdpardRxPort
 {
-    /// For subject ports this is the subject-ID. For RPC-service ports this is the service-ID.
-    /// READ-ONLY
-    UdpardPortID port_id;
-
     /// The maximum payload size that can be accepted at this port.
     /// The rest will be truncated away following the implicit truncation rule defined in the Cyphal specification.
     /// READ-ONLY
@@ -877,6 +873,9 @@ struct UdpardRxRPC
 {
     /// READ-ONLY
     struct UdpardTreeNode base;
+
+    /// READ-ONLY
+    UdpardPortID service_id;
 
     /// See UdpardRxPort.
     /// Use this to change the transfer-ID timeout value for this RPC-service port.

--- a/libudpard/udpard.h
+++ b/libudpard/udpard.h
@@ -346,14 +346,14 @@ typedef void* (*UdpardMemoryAllocate)(void* const user_reference, const size_t s
 ///     - The execution time should be constant (O(1)).
 ///
 /// The value of the user reference is taken from the corresponding field of the memory resource structure.
-typedef void (*UdpardMemoryFree)(void* const user_reference, const size_t size, void* const pointer);
+typedef void (*UdpardMemoryDeallocate)(void* const user_reference, const size_t size, void* const pointer);
 
 /// A kind of memory resource that can only be used to free memory previously allocated by the user.
 /// Instances are mostly intended to be passed by value.
 struct UdpardMemoryDeleter
 {
-    void*            user_reference;  ///< Passed as the first argument.
-    UdpardMemoryFree free;            ///< Shall be a valid pointer.
+    void*                  user_reference;  ///< Passed as the first argument.
+    UdpardMemoryDeallocate deallocate;      ///< Shall be a valid pointer.
 };
 
 /// A memory resource encapsulates the dynamic memory allocation and deallocation facilities.
@@ -362,9 +362,9 @@ struct UdpardMemoryDeleter
 /// Instances are mostly intended to be passed by value.
 struct UdpardMemoryResource
 {
-    void*                user_reference;  ///< Passed as the first argument.
-    UdpardMemoryFree     free;            ///< Shall be a valid pointer.
-    UdpardMemoryAllocate allocate;        ///< Shall be a valid pointer.
+    void*                  user_reference;  ///< Passed as the first argument.
+    UdpardMemoryDeallocate deallocate;      ///< Shall be a valid pointer.
+    UdpardMemoryAllocate   allocate;        ///< Shall be a valid pointer.
 };
 
 // =====================================================================================================================

--- a/libudpard/udpard.h
+++ b/libudpard/udpard.h
@@ -237,10 +237,10 @@ extern "C" {
 /// The library supports at most this many redundant network interfaces per Cyphal node.
 #define UDPARD_NETWORK_INTERFACE_COUNT_MAX 3U
 
-typedef uint64_t UdpardMicrosecond;
+typedef uint64_t UdpardMicrosecond;  ///< UINT64_MAX is not a valid timestamp value.
 typedef uint16_t UdpardPortID;
 typedef uint16_t UdpardNodeID;
-typedef uint64_t UdpardTransferID;
+typedef uint64_t UdpardTransferID;  ///< UINT64_MAX is not a valid transfer-ID value.
 
 /// Transfer priority level mnemonics per the recommendations given in the Cyphal Specification.
 /// For outgoing transfers they are mapped to DSCP values as configured per redundant interface (per UdpardTx instance).

--- a/libudpard/udpard.h
+++ b/libudpard/udpard.h
@@ -113,7 +113,9 @@
 /// Said pipelines are entirely independent from each other and can be operated from different threads,
 /// as they share no resources.
 ///
-/// The reception pipeline is able to accept datagrams with arbitrary MTU.
+/// The reception pipeline is able to accept datagrams with arbitrary MTU, frames delivered out-of-order (OOO) with
+/// arbitrary duplication, including duplication of non-adjacent frames, and/or frames interleaved between adjacent
+/// transfers. The support for OOO reassembly is particularly interesting when simple repetition coding FEC is used.
 ///
 /// The application should instantiate one subscription instance per subject it needs to receive messages from,
 /// irrespective of the number of redundant interfaces. There needs to be one socket (or a similar abstraction
@@ -758,8 +760,8 @@ struct UdpardRxTransfer
 ///
 /// If any of the arguments are NULL, the function has no effect.
 void udpardRxFragmentFree(const struct UdpardFragment       head,
-                          struct UdpardMemoryResource const memory_fragment,
-                          struct UdpardMemoryDeleter const  memory_payload);
+                          const struct UdpardMemoryResource memory_fragment,
+                          const struct UdpardMemoryDeleter  memory_payload);
 
 // ---------------------------------------------  SUBJECTS  ---------------------------------------------
 

--- a/libudpard/udpard.h
+++ b/libudpard/udpard.h
@@ -739,13 +739,16 @@ struct UdpardRxTransfer
 };
 
 /// This is, essentially, a helper that frees the memory allocated for the payload and its fragment headers
-/// using the correct memory resource. The application can do the same thing manually if it has access to the
+/// using the correct memory resources. The application can do the same thing manually if it has access to the
 /// required context to compute the size, or if the memory resource implementation does not require deallocation size.
 ///
+/// The head of the fragment list is passed by value so it is not freed. This is in line with the UdpardRxTransfer
+/// design, where the head is stored by value to reduce indirection in small transfers. We call it Scott's Head.
+///
 /// If any of the arguments are NULL, the function has no effect.
-void udpardRxTransferFree(struct UdpardRxTransfer* const     self,
-                          struct UdpardMemoryResource* const memory_fragment,
-                          struct UdpardMemoryResource* const memory_payload);
+void udpardFragmentFree(const struct UdpardFragment        head,
+                        struct UdpardMemoryResource* const memory_fragment,
+                        struct UdpardMemoryResource* const memory_payload);
 
 // ---------------------------------------------  SUBJECTS  ---------------------------------------------
 

--- a/tests/.idea/dictionaries/pavel.xml
+++ b/tests/.idea/dictionaries/pavel.xml
@@ -8,6 +8,7 @@
       <w>dscp</w>
       <w>dudpard</w>
       <w>ghcr</w>
+      <w>iface</w>
       <w>ifaces</w>
       <w>intravehicular</w>
       <w>libcanard</w>
@@ -20,6 +21,7 @@
       <w>nosonar</w>
       <w>opencyphal</w>
       <w>profraw</w>
+      <w>pycyphal</w>
       <w>stringmakers</w>
       <w>udpard</w>
       <w>udpip</w>

--- a/tests/.idea/dictionaries/pavel.xml
+++ b/tests/.idea/dictionaries/pavel.xml
@@ -4,6 +4,7 @@
       <w>baremetal</w>
       <w>cfamily</w>
       <w>deallocation</w>
+      <w>deduplicator</w>
       <w>discardment</w>
       <w>dscp</w>
       <w>dudpard</w>

--- a/tests/.idea/dictionaries/pavel.xml
+++ b/tests/.idea/dictionaries/pavel.xml
@@ -9,6 +9,7 @@
       <w>discardment</w>
       <w>dscp</w>
       <w>dudpard</w>
+      <w>ffee</w>
       <w>ghcr</w>
       <w>iface</w>
       <w>ifaces</w>

--- a/tests/.idea/dictionaries/pavel.xml
+++ b/tests/.idea/dictionaries/pavel.xml
@@ -25,6 +25,7 @@
       <w>prio</w>
       <w>profraw</w>
       <w>pycyphal</w>
+      <w>spdx</w>
       <w>stringmakers</w>
       <w>udpard</w>
       <w>udpip</w>

--- a/tests/.idea/dictionaries/pavel.xml
+++ b/tests/.idea/dictionaries/pavel.xml
@@ -20,6 +20,7 @@
       <w>mmcu</w>
       <w>nosonar</w>
       <w>opencyphal</w>
+      <w>prio</w>
       <w>profraw</w>
       <w>pycyphal</w>
       <w>stringmakers</w>

--- a/tests/.idea/dictionaries/pavel.xml
+++ b/tests/.idea/dictionaries/pavel.xml
@@ -4,16 +4,19 @@
       <w>baremetal</w>
       <w>cavl</w>
       <w>cfamily</w>
+      <w>cyphal</w>
       <w>deallocation</w>
       <w>deduplicator</w>
       <w>discardment</w>
       <w>dscp</w>
+      <w>dsdl</w>
       <w>dudpard</w>
       <w>ffee</w>
       <w>ghcr</w>
       <w>iface</w>
       <w>ifaces</w>
       <w>intravehicular</w>
+      <w>kirienko</w>
       <w>libcanard</w>
       <w>libgtest</w>
       <w>libudpard</w>
@@ -23,6 +26,7 @@
       <w>mmcu</w>
       <w>nosonar</w>
       <w>opencyphal</w>
+      <w>pard</w>
       <w>prio</w>
       <w>profraw</w>
       <w>pycyphal</w>

--- a/tests/.idea/dictionaries/pavel.xml
+++ b/tests/.idea/dictionaries/pavel.xml
@@ -2,6 +2,7 @@
   <dictionary name="pavel">
     <words>
       <w>baremetal</w>
+      <w>cavl</w>
       <w>cfamily</w>
       <w>deallocation</w>
       <w>deduplicator</w>

--- a/tests/.idea/dictionaries/pavel.xml
+++ b/tests/.idea/dictionaries/pavel.xml
@@ -8,6 +8,7 @@
       <w>dscp</w>
       <w>dudpard</w>
       <w>ghcr</w>
+      <w>ifaces</w>
       <w>intravehicular</w>
       <w>libcanard</w>
       <w>libgtest</w>

--- a/tests/src/helpers.h
+++ b/tests/src/helpers.h
@@ -45,7 +45,7 @@ static inline void* dummyAllocatorAllocate(void* const user_reference, const siz
     return NULL;
 }
 
-static inline void dummyAllocatorFree(void* const user_reference, const size_t size, void* const pointer)
+static inline void dummyAllocatorDeallocate(void* const user_reference, const size_t size, void* const pointer)
 {
     (void) user_reference;
     (void) size;
@@ -99,7 +99,7 @@ static inline void* instrumentedAllocatorAllocate(void* const user_reference, co
     return result;
 }
 
-static inline void instrumentedAllocatorFree(void* const user_reference, const size_t size, void* const pointer)
+static inline void instrumentedAllocatorDeallocate(void* const user_reference, const size_t size, void* const pointer)
 {
     InstrumentedAllocator* const self = (InstrumentedAllocator*) user_reference;
     if (pointer != NULL)
@@ -146,14 +146,15 @@ static inline struct UdpardMemoryResource instrumentedAllocatorMakeMemoryResourc
     const InstrumentedAllocator* const self)
 {
     const struct UdpardMemoryResource out = {.user_reference = (void*) self,
-                                             .free           = &instrumentedAllocatorFree,
+                                             .deallocate     = &instrumentedAllocatorDeallocate,
                                              .allocate       = &instrumentedAllocatorAllocate};
     return out;
 }
 
 static inline struct UdpardMemoryDeleter instrumentedAllocatorMakeMemoryDeleter(const InstrumentedAllocator* const self)
 {
-    const struct UdpardMemoryDeleter out = {.user_reference = (void*) self, .free = &instrumentedAllocatorFree};
+    const struct UdpardMemoryDeleter out = {.user_reference = (void*) self,
+                                            .deallocate     = &instrumentedAllocatorDeallocate};
     return out;
 }
 

--- a/tests/src/helpers.h
+++ b/tests/src/helpers.h
@@ -38,17 +38,17 @@ extern "C" {
         }                            \
     } while (0)
 
-static inline void* dummyAllocatorAllocate(struct UdpardMemoryResource* const self, const size_t size)
+static inline void* dummyAllocatorAllocate(void* const user_reference, const size_t size)
 {
-    (void) self;
+    (void) user_reference;
     (void) size;
     return NULL;
 }
 
-static inline void dummyAllocatorFree(struct UdpardMemoryResource* const self, const size_t size, void* const pointer)
+static inline void dummyAllocatorFree(void* const user_reference, const size_t size, void* const pointer)
 {
+    (void) user_reference;
     (void) size;
-    TEST_PANIC_UNLESS(self != NULL);
     TEST_PANIC_UNLESS(pointer == NULL);
 }
 
@@ -57,8 +57,7 @@ static inline void dummyAllocatorFree(struct UdpardMemoryResource* const self, c
 #define INSTRUMENTED_ALLOCATOR_CANARY_SIZE 1024U
 typedef struct
 {
-    struct UdpardMemoryResource base;
-    uint_least8_t               canary[INSTRUMENTED_ALLOCATOR_CANARY_SIZE];
+    uint_least8_t canary[INSTRUMENTED_ALLOCATOR_CANARY_SIZE];
     /// The limit can be changed at any moment to control the maximum amount of memory that can be allocated.
     /// It may be set to a value less than the currently allocated amount.
     size_t limit_fragments;
@@ -68,11 +67,10 @@ typedef struct
     size_t allocated_bytes;
 } InstrumentedAllocator;
 
-static inline void* instrumentedAllocatorAllocate(struct UdpardMemoryResource* const base, const size_t size)
+static inline void* instrumentedAllocatorAllocate(void* const user_reference, const size_t size)
 {
-    InstrumentedAllocator* const self = (InstrumentedAllocator*) base;
-    TEST_PANIC_UNLESS(self->base.allocate == &instrumentedAllocatorAllocate);
-    void* result = NULL;
+    InstrumentedAllocator* const self   = (InstrumentedAllocator*) user_reference;
+    void*                        result = NULL;
     if ((size > 0U) &&                                            //
         ((self->allocated_bytes + size) <= self->limit_bytes) &&  //
         ((self->allocated_fragments + 1U) <= self->limit_fragments))
@@ -101,13 +99,9 @@ static inline void* instrumentedAllocatorAllocate(struct UdpardMemoryResource* c
     return result;
 }
 
-static inline void instrumentedAllocatorFree(struct UdpardMemoryResource* const base,
-                                             const size_t                       size,
-                                             void* const                        pointer)
+static inline void instrumentedAllocatorFree(void* const user_reference, const size_t size, void* const pointer)
 {
-    InstrumentedAllocator* const self = (InstrumentedAllocator*) base;
-    TEST_PANIC_UNLESS(self->base.allocate == &instrumentedAllocatorAllocate);
-    TEST_PANIC_UNLESS(self->base.free == &instrumentedAllocatorFree);
+    InstrumentedAllocator* const self = (InstrumentedAllocator*) user_reference;
     if (pointer != NULL)
     {
         uint_least8_t* p         = ((uint_least8_t*) pointer) - INSTRUMENTED_ALLOCATOR_CANARY_SIZE;
@@ -138,9 +132,6 @@ static inline void instrumentedAllocatorFree(struct UdpardMemoryResource* const 
 /// By default, the limit is unrestricted (set to the maximum possible value).
 static inline void instrumentedAllocatorNew(InstrumentedAllocator* const self)
 {
-    self->base.allocate       = &instrumentedAllocatorAllocate;
-    self->base.free           = &instrumentedAllocatorFree;
-    self->base.user_reference = NULL;
     for (size_t i = 0; i < INSTRUMENTED_ALLOCATOR_CANARY_SIZE; i++)
     {
         self->canary[i] = (uint_least8_t) (rand() % (UINT_LEAST8_MAX + 1));
@@ -149,6 +140,21 @@ static inline void instrumentedAllocatorNew(InstrumentedAllocator* const self)
     self->limit_bytes         = SIZE_MAX;
     self->allocated_fragments = 0U;
     self->allocated_bytes     = 0U;
+}
+
+static inline struct UdpardMemoryResource instrumentedAllocatorMakeMemoryResource(
+    const InstrumentedAllocator* const self)
+{
+    const struct UdpardMemoryResource out = {.user_reference = (void*) self,
+                                             .free           = &instrumentedAllocatorFree,
+                                             .allocate       = &instrumentedAllocatorAllocate};
+    return out;
+}
+
+static inline struct UdpardMemoryDeleter instrumentedAllocatorMakeMemoryDeleter(const InstrumentedAllocator* const self)
+{
+    const struct UdpardMemoryDeleter out = {.user_reference = (void*) self, .free = &instrumentedAllocatorFree};
+    return out;
 }
 
 #ifdef __cplusplus

--- a/tests/src/hexdump.hpp
+++ b/tests/src/hexdump.hpp
@@ -11,14 +11,16 @@
 
 namespace hexdump
 {
-template <std::uint8_t BytesPerRow = 16, typename InputIterator>
+using Byte = std::uint_least8_t;
+
+template <Byte BytesPerRow = 16, typename InputIterator>
 [[nodiscard]] std::string hexdump(InputIterator begin, const InputIterator end)
 {
     static_assert(BytesPerRow > 0);
-    static constexpr std::pair<std::uint8_t, std::uint8_t> PrintableASCIIRange{32, 126};
-    std::uint32_t                                          offset = 0;
-    std::ostringstream                                     output;
-    bool                                                   first = true;
+    static constexpr std::pair<Byte, Byte> PrintableASCIIRange{32, 126};
+    std::uint32_t                          offset = 0;
+    std::ostringstream                     output;
+    bool                                   first = true;
     output << std::hex << std::setfill('0');
     do
     {
@@ -33,7 +35,7 @@ template <std::uint8_t BytesPerRow = 16, typename InputIterator>
         output << std::setw(8) << offset << "  ";
         offset += BytesPerRow;
         auto it = begin;
-        for (std::uint8_t i = 0; i < BytesPerRow; ++i)
+        for (Byte i = 0; i < BytesPerRow; ++i)
         {
             if (i == 8)
             {
@@ -50,7 +52,7 @@ template <std::uint8_t BytesPerRow = 16, typename InputIterator>
             }
         }
         output << " ";
-        for (std::uint8_t i = 0; i < BytesPerRow; ++i)
+        for (Byte i = 0; i < BytesPerRow; ++i)
         {
             if (begin != end)
             {
@@ -76,6 +78,6 @@ template <std::uint8_t BytesPerRow = 16, typename InputIterator>
 
 [[nodiscard]] inline auto hexdump(const void* const data, const std::size_t size)
 {
-    return hexdump(static_cast<const std::uint8_t*>(data), static_cast<const std::uint8_t*>(data) + size);
+    return hexdump(static_cast<const Byte*>(data), static_cast<const Byte*>(data) + size);
 }
 }  // namespace hexdump

--- a/tests/src/test_cavl.cpp
+++ b/tests/src/test_cavl.cpp
@@ -31,10 +31,10 @@ struct Node final : Cavl
 
     T value{};
 
-    auto checkLinkageUpLeftRightBF(const Cavl* const check_up,
-                                   const Cavl* const check_le,
-                                   const Cavl* const check_ri,
-                                   const std::int8_t check_bf) const -> bool
+    auto checkLinkageUpLeftRightBF(const Cavl* const      check_up,
+                                   const Cavl* const      check_le,
+                                   const Cavl* const      check_ri,
+                                   const std::int_fast8_t check_bf) const -> bool
     {
         return (up == check_up) &&                                                                   //
                (lr[0] == check_le) && (lr[1] == check_ri) &&                                         //
@@ -64,7 +64,7 @@ auto search(Node<T>** const root, const Predicate& predicate, const Factory& fac
         Predicate predicate;
         Factory   factory;
 
-        static auto callPredicate(void* const user_reference, const Cavl* const node) -> std::int8_t
+        static auto callPredicate(void* const user_reference, const Cavl* const node) -> std::int_fast8_t
         {
             const auto ret = static_cast<Refs*>(user_reference)->predicate(static_cast<const Node<T>&>(*node));
             if (ret > 0)
@@ -101,20 +101,20 @@ void remove(Node<T>** const root, const Node<T>* const n)
 }
 
 template <typename T>
-auto getHeight(const Node<T>* const n) -> std::uint8_t  // NOLINT recursion
+auto getHeight(const Node<T>* const n) -> std::uint_fast8_t  // NOLINT recursion
 {
-    return (n != nullptr) ? static_cast<std::uint8_t>(1U + std::max(getHeight(static_cast<Node<T>*>(n->lr[0])),
-                                                                    getHeight(static_cast<Node<T>*>(n->lr[1]))))
+    return (n != nullptr) ? static_cast<std::uint_fast8_t>(1U + std::max(getHeight(static_cast<Node<T>*>(n->lr[0])),
+                                                                         getHeight(static_cast<Node<T>*>(n->lr[1]))))
                           : 0;
 }
 
 template <typename T>
-void print(const Node<T>* const nd, const std::uint8_t depth = 0, const char marker = 'T')  // NOLINT recursion
+void print(const Node<T>* const nd, const std::uint_fast8_t depth = 0, const char marker = 'T')  // NOLINT recursion
 {
     TEST_ASSERT(10 > getHeight(nd));  // Fail early for malformed cyclic trees, do not overwhelm stdout.
     if (nd != nullptr)
     {
-        print<T>(static_cast<const Node<T>*>(nd->lr[0]), static_cast<std::uint8_t>(depth + 1U), 'L');
+        print<T>(static_cast<const Node<T>*>(nd->lr[0]), static_cast<std::uint_fast8_t>(depth + 1U), 'L');
         for (std::uint16_t i = 1U; i < depth; i++)
         {
             std::cout << "              ";
@@ -133,7 +133,7 @@ void print(const Node<T>* const nd, const std::uint8_t depth = 0, const char mar
         }
         std::cout << marker << "=" << static_cast<std::int64_t>(nd->value)  //
                   << " [" << static_cast<std::int16_t>(nd->bf) << "]" << std::endl;
-        print<T>(static_cast<const Node<T>*>(nd->lr[1]), static_cast<std::uint8_t>(depth + 1U), 'R');
+        print<T>(static_cast<const Node<T>*>(nd->lr[1]), static_cast<std::uint_fast8_t>(depth + 1U), 'R');
     }
 }
 
@@ -211,7 +211,7 @@ auto findBrokenBalanceFactor(const Node<T>* const n) -> const Cavl*  // NOLINT r
 
 void testCheckAscension()
 {
-    using N = Node<std::uint8_t>;
+    using N = Node<std::uint_fast8_t>;
     N t{2};
     N l{1};
     N r{3};
@@ -238,7 +238,7 @@ void testCheckAscension()
 
 void testRotation()
 {
-    using N = Node<std::uint8_t>;
+    using N = Node<std::uint_fast8_t>;
     // Original state:
     //      x.left  = a
     //      x.right = z
@@ -284,7 +284,7 @@ void testRotation()
 
 void testBalancingA()
 {
-    using N = Node<std::uint8_t>;
+    using N = Node<std::uint_fast8_t>;
     // Double left-right rotation.
     //     X             X           Y
     //    / `           / `        /   `
@@ -334,7 +334,7 @@ void testBalancingA()
 
 void testBalancingB()
 {
-    using N = Node<std::uint8_t>;
+    using N = Node<std::uint_fast8_t>;
     // Without F the handling of Z and Y is more complex; Z flips the sign of its balance factor:
     //     X             X           Y
     //    / `           / `        /   `
@@ -383,7 +383,7 @@ void testBalancingB()
 
 void testBalancingC()
 {
-    using N = Node<std::uint8_t>;
+    using N = Node<std::uint_fast8_t>;
     // Both X and Z are heavy on the same side.
     //       X              Z
     //      / `           /   `
@@ -434,9 +434,9 @@ void testBalancingC()
 
 void testRetracingOnGrowth()
 {
-    using N = Node<std::uint8_t>;
+    using N = Node<std::uint_fast8_t>;
     std::array<N, 100> t{};
-    for (std::uint8_t i = 0; i < 100; i++)
+    for (std::uint_fast8_t i = 0; i < 100; i++)
     {
         t[i].value = i;
     }
@@ -640,7 +640,7 @@ void testRetracingOnGrowth()
 
 void testSearchTrivial()
 {
-    using N = Node<std::uint8_t>;
+    using N = Node<std::uint_fast8_t>;
     //      A
     //    B   C
     //   D E F G
@@ -684,7 +684,7 @@ void testSearchTrivial()
 
 void testRemovalA()
 {
-    using N = Node<std::uint8_t>;
+    using N = Node<std::uint_fast8_t>;
     //        4
     //      /   `
     //    2       6
@@ -693,7 +693,7 @@ void testRemovalA()
     //             / `
     //            7   9
     std::array<N, 10> t{};
-    for (std::uint8_t i = 0; i < 10; i++)
+    for (std::uint_fast8_t i = 0; i < 10; i++)
     {
         t[i].value = i;
     }
@@ -1005,7 +1005,7 @@ void testRemovalA()
 
 void testMutationManual()
 {
-    using N = Node<std::uint8_t>;
+    using N = Node<std::uint_fast8_t>;
     // Build a tree with 31 elements from 1 to 31 inclusive by adding new elements successively:
     //                               16
     //                       /               `
@@ -1017,13 +1017,13 @@ void testMutationManual()
     //  / `     / `     / `     / `     / `     / `     / `     / `
     // 1   3   5   7   9  11  13  15  17  19  21  23  25  27  29  31
     std::array<N, 32> t{};
-    for (std::uint8_t i = 0; i < 32; i++)
+    for (std::uint_fast8_t i = 0; i < 32; i++)
     {
         t[i].value = i;
     }
     // Build the actual tree.
     N* root = nullptr;
-    for (std::uint8_t i = 1; i < 32; i++)
+    for (std::uint_fast8_t i = 1; i < 32; i++)
     {
         const auto pred = [&](const N& v) { return t.at(i).value - v.value; };
         TEST_ASSERT(nullptr == search(&root, pred));
@@ -1276,16 +1276,16 @@ void testMutationManual()
 
 auto getRandomByte()
 {
-    return static_cast<std::uint8_t>((0xFFLL * std::rand()) / RAND_MAX);
+    return static_cast<std::uint_fast8_t>((0xFFLL * std::rand()) / RAND_MAX);
 }
 
 void testMutationRandomized()
 {
-    using N = Node<std::uint8_t>;
+    using N = Node<std::uint_fast8_t>;
     std::array<N, 256> t{};
     for (auto i = 0U; i < 256U; i++)
     {
-        t.at(i).value = static_cast<std::uint8_t>(i);
+        t.at(i).value = static_cast<std::uint_fast8_t>(i);
     }
     std::array<bool, 256> mask{};
     std::size_t           size = 0;
@@ -1307,7 +1307,7 @@ void testMutationRandomized()
     };
     validate();
 
-    const auto add = [&](const std::uint8_t x) {
+    const auto add = [&](const std::uint_fast8_t x) {
         const auto predicate = [&](const N& v) { return x - v.value; };
         if (N* const existing = search(&root, predicate))
         {
@@ -1332,7 +1332,7 @@ void testMutationRandomized()
         }
     };
 
-    const auto drop = [&](const std::uint8_t x) {
+    const auto drop = [&](const std::uint_fast8_t x) {
         const auto predicate = [&](const N& v) { return x - v.value; };
         if (N* const existing = search(&root, predicate))
         {

--- a/tests/src/test_helpers.c
+++ b/tests/src/test_helpers.c
@@ -37,7 +37,7 @@ static void testInstrumentedAllocator(void)
     TEST_ASSERT_EQUAL_size_t(3, al.allocated_fragments);
     TEST_ASSERT_EQUAL_size_t(600, al.allocated_bytes);
 
-    resource.free(resource.user_reference, 123, a);
+    resource.deallocate(resource.user_reference, 123, a);
     TEST_ASSERT_EQUAL_size_t(2, al.allocated_fragments);
     TEST_ASSERT_EQUAL_size_t(477, al.allocated_bytes);
 
@@ -45,15 +45,15 @@ static void testInstrumentedAllocator(void)
     TEST_ASSERT_EQUAL_size_t(3, al.allocated_fragments);
     TEST_ASSERT_EQUAL_size_t(577, al.allocated_bytes);
 
-    resource.free(resource.user_reference, 21, c);
+    resource.deallocate(resource.user_reference, 21, c);
     TEST_ASSERT_EQUAL_size_t(2, al.allocated_fragments);
     TEST_ASSERT_EQUAL_size_t(556, al.allocated_bytes);
 
-    resource.free(resource.user_reference, 100, d);
+    resource.deallocate(resource.user_reference, 100, d);
     TEST_ASSERT_EQUAL_size_t(1, al.allocated_fragments);
     TEST_ASSERT_EQUAL_size_t(456, al.allocated_bytes);
 
-    resource.free(resource.user_reference, 456, b);
+    resource.deallocate(resource.user_reference, 456, b);
     TEST_ASSERT_EQUAL_size_t(0, al.allocated_fragments);
     TEST_ASSERT_EQUAL_size_t(0, al.allocated_bytes);
 }

--- a/tests/src/test_helpers.c
+++ b/tests/src/test_helpers.c
@@ -11,47 +11,49 @@ static void testInstrumentedAllocator(void)
     TEST_ASSERT_EQUAL_size_t(0, al.allocated_fragments);
     TEST_ASSERT_EQUAL_size_t(SIZE_MAX, al.limit_bytes);
 
-    void* a = al.base.allocate(&al.base, 123);
+    const struct UdpardMemoryResource resource = instrumentedAllocatorMakeMemoryResource(&al);
+
+    void* a = resource.allocate(resource.user_reference, 123);
     TEST_ASSERT_EQUAL_size_t(1, al.allocated_fragments);
     TEST_ASSERT_EQUAL_size_t(123, al.allocated_bytes);
 
-    void* b = al.base.allocate(&al.base, 456);
+    void* b = resource.allocate(resource.user_reference, 456);
     TEST_ASSERT_EQUAL_size_t(2, al.allocated_fragments);
     TEST_ASSERT_EQUAL_size_t(579, al.allocated_bytes);
 
     al.limit_bytes     = 600;
     al.limit_fragments = 2;
 
-    TEST_ASSERT_EQUAL_PTR(NULL, al.base.allocate(&al.base, 100));
+    TEST_ASSERT_EQUAL_PTR(NULL, resource.allocate(resource.user_reference, 100));
     TEST_ASSERT_EQUAL_size_t(2, al.allocated_fragments);
     TEST_ASSERT_EQUAL_size_t(579, al.allocated_bytes);
 
-    TEST_ASSERT_EQUAL_PTR(NULL, al.base.allocate(&al.base, 21));
+    TEST_ASSERT_EQUAL_PTR(NULL, resource.allocate(resource.user_reference, 21));
     TEST_ASSERT_EQUAL_size_t(2, al.allocated_fragments);
     TEST_ASSERT_EQUAL_size_t(579, al.allocated_bytes);
     al.limit_fragments = 4;
 
-    void* c = al.base.allocate(&al.base, 21);
+    void* c = resource.allocate(resource.user_reference, 21);
     TEST_ASSERT_EQUAL_size_t(3, al.allocated_fragments);
     TEST_ASSERT_EQUAL_size_t(600, al.allocated_bytes);
 
-    al.base.free(&al.base, 123, a);
+    resource.free(resource.user_reference, 123, a);
     TEST_ASSERT_EQUAL_size_t(2, al.allocated_fragments);
     TEST_ASSERT_EQUAL_size_t(477, al.allocated_bytes);
 
-    void* d = al.base.allocate(&al.base, 100);
+    void* d = resource.allocate(resource.user_reference, 100);
     TEST_ASSERT_EQUAL_size_t(3, al.allocated_fragments);
     TEST_ASSERT_EQUAL_size_t(577, al.allocated_bytes);
 
-    al.base.free(&al.base, 21, c);
+    resource.free(resource.user_reference, 21, c);
     TEST_ASSERT_EQUAL_size_t(2, al.allocated_fragments);
     TEST_ASSERT_EQUAL_size_t(556, al.allocated_bytes);
 
-    al.base.free(&al.base, 100, d);
+    resource.free(resource.user_reference, 100, d);
     TEST_ASSERT_EQUAL_size_t(1, al.allocated_fragments);
     TEST_ASSERT_EQUAL_size_t(456, al.allocated_bytes);
 
-    al.base.free(&al.base, 456, b);
+    resource.free(resource.user_reference, 456, b);
     TEST_ASSERT_EQUAL_size_t(0, al.allocated_fragments);
     TEST_ASSERT_EQUAL_size_t(0, al.allocated_bytes);
 }

--- a/tests/src/test_helpers.c
+++ b/tests/src/test_helpers.c
@@ -19,11 +19,17 @@ static void testInstrumentedAllocator(void)
     TEST_ASSERT_EQUAL_size_t(2, al.allocated_fragments);
     TEST_ASSERT_EQUAL_size_t(579, al.allocated_bytes);
 
-    al.limit_bytes = 600;
+    al.limit_bytes     = 600;
+    al.limit_fragments = 2;
 
     TEST_ASSERT_EQUAL_PTR(NULL, al.base.allocate(&al.base, 100));
     TEST_ASSERT_EQUAL_size_t(2, al.allocated_fragments);
     TEST_ASSERT_EQUAL_size_t(579, al.allocated_bytes);
+
+    TEST_ASSERT_EQUAL_PTR(NULL, al.base.allocate(&al.base, 21));
+    TEST_ASSERT_EQUAL_size_t(2, al.allocated_fragments);
+    TEST_ASSERT_EQUAL_size_t(579, al.allocated_bytes);
+    al.limit_fragments = 4;
 
     void* c = al.base.allocate(&al.base, 21);
     TEST_ASSERT_EQUAL_size_t(3, al.allocated_fragments);

--- a/tests/src/test_intrusive_rx.c
+++ b/tests/src/test_intrusive_rx.c
@@ -303,7 +303,7 @@ static void testSlotEjectValidLarge(void)
                                 "Where does the universe come from? ";
     // Build the fragment tree:
     //      2
-    //     / \
+    //     / `
     //    1   3
     //   /
     //  0
@@ -388,9 +388,9 @@ static void testSlotEjectValidSmall(void)
                                    "More like a puddle. The sea has gone dry.";
     // Build the fragment tree:
     //      1
-    //     / \
+    //     / `
     //    0   3
-    //       / \
+    //       / `
     //      2   4
     RxFragment* const root =                      //
         makeRxFragmentString(&mem_fragment.base,  //
@@ -471,7 +471,7 @@ static void testSlotEjectValidEmpty(void)
     instrumentedAllocatorNew(&mem_payload);
     // Build the fragment tree:
     //      1
-    //     / \
+    //     / `
     //    0   2
     RxFragment* const root = makeRxFragmentString(&mem_fragment.base, &mem_payload.base, 1, "BBB", NULL);
     root->tree.base.lr[0] =
@@ -518,7 +518,7 @@ static void testSlotEjectInvalid(void)
     instrumentedAllocatorNew(&mem_payload);
     // Build the fragment tree; no valid CRC here:
     //      1
-    //     / \
+    //     / `
     //    0   2
     RxFragment* const root = makeRxFragmentString(&mem_fragment.base, &mem_payload.base, 1, "BBB", NULL);
     root->tree.base.lr[0] =
@@ -547,6 +547,11 @@ static void testSlotEjectInvalid(void)
     TEST_ASSERT_EQUAL(0, mem_fragment.allocated_bytes);
 }
 
+static void testSlotUpdateA(void)
+{
+    //
+}
+
 void setUp(void) {}
 
 void tearDown(void) {}
@@ -570,6 +575,7 @@ int main(void)
     RUN_TEST(testSlotEjectValidSmall);
     RUN_TEST(testSlotEjectValidEmpty);
     RUN_TEST(testSlotEjectInvalid);
+    RUN_TEST(testSlotUpdateA);
     return UNITY_END();
 }
 

--- a/tests/src/test_intrusive_rx.c
+++ b/tests/src/test_intrusive_rx.c
@@ -111,6 +111,16 @@ static RxFrameBase makeRxFrameBaseString(struct UdpardMemoryResource* const memo
                            (struct UdpardMutablePayload){.data = (void*) payload, .size = strlen(payload)});
 }
 
+static RxFrame makeRxFrameString(struct UdpardMemoryResource* const memory_payload,
+                                 const TransferMetadata             meta,
+                                 const uint32_t                     frame_index,
+                                 const bool                         end_of_transfer,
+                                 const char* const                  payload)
+{
+    return (RxFrame){.base = makeRxFrameBaseString(memory_payload, frame_index, end_of_transfer, payload),
+                     .meta = meta};
+}
+
 // --------------------------------------------------------------------------------------------------------------------
 
 // Generate reference data using PyCyphal:
@@ -1000,6 +1010,17 @@ static void testSlotAcceptA(void)
     TEST_ASSERT_NULL(slot.fragments);
 }
 
+static void testIfaceAcceptA(void)
+{
+    InstrumentedAllocator mem_fragment = {0};
+    InstrumentedAllocator mem_payload  = {0};
+    instrumentedAllocatorNew(&mem_fragment);
+    instrumentedAllocatorNew(&mem_payload);
+    RxIface iface;
+    rxIfaceInit(&iface, &mem_fragment.base, &mem_payload.base);
+    (void) makeRxFrameString;
+}
+
 void setUp(void) {}
 
 void tearDown(void) {}
@@ -1007,6 +1028,7 @@ void tearDown(void) {}
 int main(void)
 {
     UNITY_BEGIN();
+    // frame parser
     RUN_TEST(testParseFrameValidMessage);
     RUN_TEST(testParseFrameValidRPCService);
     RUN_TEST(testParseFrameValidMessageAnonymous);
@@ -1017,6 +1039,7 @@ int main(void)
     RUN_TEST(testParseFrameUnknownHeaderVersion);
     RUN_TEST(testParseFrameHeaderWithoutPayload);
     RUN_TEST(testParseFrameEmpty);
+    // slot
     RUN_TEST(testSlotRestartEmpty);
     RUN_TEST(testSlotRestartNonEmpty);
     RUN_TEST(testSlotEjectValidLarge);
@@ -1024,6 +1047,8 @@ int main(void)
     RUN_TEST(testSlotEjectValidEmpty);
     RUN_TEST(testSlotEjectInvalid);
     RUN_TEST(testSlotAcceptA);
+    // iface
+    RUN_TEST(testIfaceAcceptA);
     return UNITY_END();
 }
 

--- a/tests/src/test_intrusive_rx.c
+++ b/tests/src/test_intrusive_rx.c
@@ -470,7 +470,7 @@ static void testSlotEjectValidLarge(void)
     TEST_ASSERT_EQUAL(3, mem_fragment.allocated_fragments);                   // One gone!!1
     TEST_ASSERT_EQUAL(sizeof(RxFragment) * 3, mem_fragment.allocated_bytes);  // yes yes!
     // Now, free the payload as the application would.
-    udpardFragmentFree(payload, &mem_fragment.base, &mem_payload.base);
+    udpardRxFragmentFree(payload, &mem_fragment.base, &mem_payload.base);
     // All memory shall be free now. As in "free beer".
     TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);
     TEST_ASSERT_EQUAL(0, mem_payload.allocated_bytes);
@@ -540,7 +540,7 @@ static void testSlotEjectValidSmall(void)
     TEST_ASSERT_EQUAL(2, mem_fragment.allocated_fragments);  // One gone!!1
     TEST_ASSERT_EQUAL(sizeof(RxFragment) * 2, mem_fragment.allocated_bytes);
     // Now, free the payload as the application would.
-    udpardFragmentFree(payload, &mem_fragment.base, &mem_payload.base);
+    udpardRxFragmentFree(payload, &mem_fragment.base, &mem_payload.base);
     // All memory shall be free now. As in "free beer".
     TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);
     TEST_ASSERT_EQUAL(0, mem_payload.allocated_bytes);
@@ -585,7 +585,7 @@ static void testSlotEjectValidEmpty(void)
     TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
     TEST_ASSERT_EQUAL(0, mem_fragment.allocated_bytes);
     // Now, free the payload as the application would.
-    udpardFragmentFree(payload, &mem_fragment.base, &mem_payload.base);
+    udpardRxFragmentFree(payload, &mem_fragment.base, &mem_payload.base);
     // No memory is in use anyway, so no change here.
     TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);
     TEST_ASSERT_EQUAL(0, mem_payload.allocated_bytes);
@@ -672,7 +672,7 @@ static void testSlotAcceptA(void)
     TEST_ASSERT_EQUAL(53, payload_size);
     TEST_ASSERT(compareStringWithPayload("The fish responsible for drying the sea are not here.", payload.view));
     TEST_ASSERT_NULL(payload.next);
-    udpardFragmentFree(payload, &mem_fragment.base, &mem_payload.base);
+    udpardRxFragmentFree(payload, &mem_fragment.base, &mem_payload.base);
     TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);
     TEST_ASSERT_EQUAL(0, mem_payload.allocated_bytes);
     TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
@@ -735,7 +735,7 @@ static void testSlotAcceptA(void)
     TEST_ASSERT(compareStringWithPayload("They moved from one dark forest to another dark forest.",  //
                                          payload.next->next->view));
     TEST_ASSERT_NULL(payload.next->next->next);
-    udpardFragmentFree(payload, &mem_fragment.base, &mem_payload.base);
+    udpardRxFragmentFree(payload, &mem_fragment.base, &mem_payload.base);
     TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);
     TEST_ASSERT_EQUAL(0, mem_payload.allocated_bytes);
     TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
@@ -824,7 +824,7 @@ static void testSlotAcceptA(void)
     TEST_ASSERT_NOT_NULL(payload.next);
     TEST_ASSERT(compareStringWithPayload("How do we give it", payload.next->view));  // TRUNCATED
     TEST_ASSERT_NULL(payload.next->next);
-    udpardFragmentFree(payload, &mem_fragment.base, &mem_payload.base);
+    udpardRxFragmentFree(payload, &mem_fragment.base, &mem_payload.base);
     TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);
     TEST_ASSERT_EQUAL(0, mem_payload.allocated_bytes);
     TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
@@ -940,7 +940,7 @@ static void testSlotAcceptA(void)
     TEST_ASSERT_NOT_NULL(payload.next->next);
     TEST_ASSERT(compareStringWithPayload("Toss it over.", payload.next->next->view));
     TEST_ASSERT_NULL(payload.next->next->next);
-    udpardFragmentFree(payload, &mem_fragment.base, &mem_payload.base);
+    udpardRxFragmentFree(payload, &mem_fragment.base, &mem_payload.base);
     TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);
     TEST_ASSERT_EQUAL(0, mem_payload.allocated_bytes);
     TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
@@ -1218,7 +1218,7 @@ static void testIfaceAcceptA(void)
     TEST_ASSERT_EQUAL(0x1122334455667788U, transfer.transfer_id);
     TEST_ASSERT_EQUAL(12, transfer.payload_size);
     TEST_ASSERT(compareStringWithPayload("I am a tomb.", transfer.payload.view));
-    udpardFragmentFree(transfer.payload, &mem_fragment.base, &mem_payload.base);
+    udpardRxFragmentFree(transfer.payload, &mem_fragment.base, &mem_payload.base);
     TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);
     TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
     // Check the internal states of the iface.
@@ -1411,7 +1411,7 @@ static void testIfaceAcceptA(void)
     TEST_ASSERT_NOT_NULL(transfer.payload.next);
     TEST_ASSERT(compareStringWithPayload("B1", transfer.payload.next->view));
     TEST_ASSERT_NULL(transfer.payload.next->next);
-    udpardFragmentFree(transfer.payload, &mem_fragment.base, &mem_payload.base);
+    udpardRxFragmentFree(transfer.payload, &mem_fragment.base, &mem_payload.base);
     TEST_ASSERT_EQUAL(2, mem_payload.allocated_fragments);  // Only the remaining A0 A2 are left.
     TEST_ASSERT_EQUAL(2, mem_fragment.allocated_fragments);
     // A1
@@ -1447,7 +1447,7 @@ static void testIfaceAcceptA(void)
     TEST_ASSERT_NOT_NULL(transfer.payload.next->next);
     TEST_ASSERT(compareStringWithPayload("A2", transfer.payload.next->next->view));
     TEST_ASSERT_NULL(transfer.payload.next->next->next);
-    udpardFragmentFree(transfer.payload, &mem_fragment.base, &mem_payload.base);
+    udpardRxFragmentFree(transfer.payload, &mem_fragment.base, &mem_payload.base);
     TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);
     TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
 }
@@ -1625,7 +1625,7 @@ static void testIfaceAcceptB(void)
     TEST_ASSERT_NOT_NULL(transfer.payload.next->next);
     TEST_ASSERT(compareStringWithPayload("A2", transfer.payload.next->next->view));
     TEST_ASSERT_NULL(transfer.payload.next->next->next);
-    udpardFragmentFree(transfer.payload, &mem_fragment.base, &mem_payload.base);
+    udpardRxFragmentFree(transfer.payload, &mem_fragment.base, &mem_payload.base);
     TEST_ASSERT_EQUAL(1, mem_payload.allocated_fragments);  // Some memory is retained for the C0 payload.
     TEST_ASSERT_EQUAL(1, mem_fragment.allocated_fragments);
     // C0 DUPLICATE
@@ -1684,7 +1684,7 @@ static void testIfaceAcceptB(void)
     TEST_ASSERT_NOT_NULL(transfer.payload.next);
     TEST_ASSERT(compareStringWithPayload("C1", transfer.payload.next->view));
     TEST_ASSERT_NULL(transfer.payload.next->next);
-    udpardFragmentFree(transfer.payload, &mem_fragment.base, &mem_payload.base);
+    udpardRxFragmentFree(transfer.payload, &mem_fragment.base, &mem_payload.base);
     TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);  // Some memory is retained for the C0 payload.
     TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
 }
@@ -1792,7 +1792,7 @@ static void testIfaceAcceptC(void)
     TEST_ASSERT_NOT_NULL(transfer.payload.next);
     TEST_ASSERT(compareStringWithPayload("A1", transfer.payload.next->view));
     TEST_ASSERT_NULL(transfer.payload.next->next);
-    udpardFragmentFree(transfer.payload, &mem_fragment.base, &mem_payload.base);
+    udpardRxFragmentFree(transfer.payload, &mem_fragment.base, &mem_payload.base);
     TEST_ASSERT_EQUAL(1, mem_payload.allocated_fragments);  // B0 still allocated.
     TEST_ASSERT_EQUAL(1, mem_fragment.allocated_fragments);
     // C0
@@ -1847,7 +1847,7 @@ static void testIfaceAcceptC(void)
     TEST_ASSERT_NOT_NULL(transfer.payload.next);
     TEST_ASSERT(compareStringWithPayload("B1", transfer.payload.next->view));
     TEST_ASSERT_NULL(transfer.payload.next->next);
-    udpardFragmentFree(transfer.payload, &mem_fragment.base, &mem_payload.base);
+    udpardRxFragmentFree(transfer.payload, &mem_fragment.base, &mem_payload.base);
     TEST_ASSERT_EQUAL(1, mem_payload.allocated_fragments);  // C0 is still allocated.
     TEST_ASSERT_EQUAL(1, mem_fragment.allocated_fragments);
     // C1
@@ -1883,7 +1883,7 @@ static void testIfaceAcceptC(void)
     TEST_ASSERT_NOT_NULL(transfer.payload.next);
     TEST_ASSERT(compareStringWithPayload("C1", transfer.payload.next->view));
     TEST_ASSERT_NULL(transfer.payload.next->next);
-    udpardFragmentFree(transfer.payload, &mem_fragment.base, &mem_payload.base);
+    udpardRxFragmentFree(transfer.payload, &mem_fragment.base, &mem_payload.base);
     TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);
     TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
     // B0 duplicate multi-frame; shall be rejected.
@@ -2055,7 +2055,7 @@ static void testSessionAcceptA(void)
     TEST_ASSERT_EQUAL(1, mem_payload.allocated_fragments);
     TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
     // Free the payload.
-    udpardFragmentFree(transfer.payload, &mem_fragment.base, &mem_payload.base);
+    udpardRxFragmentFree(transfer.payload, &mem_fragment.base, &mem_payload.base);
     TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);
     TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
     // Send the same transfer again through a different iface; it is a duplicate and so it is rejected and freed.
@@ -2151,7 +2151,7 @@ static inline void testPortAcceptFrameA(void)
                                          "Solar System into two dimensions cease?",
                                          transfer.payload.view));
     // Free the memory.
-    udpardFragmentFree(transfer.payload, &mem_fragment.base, &mem_payload.base);
+    udpardRxFragmentFree(transfer.payload, &mem_fragment.base, &mem_payload.base);
     TEST_ASSERT_EQUAL(1, mem_session.allocated_fragments);  // The session remains.
     TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
     TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);
@@ -2182,7 +2182,7 @@ static inline void testPortAcceptFrameA(void)
     TEST_ASSERT_EQUAL(20, transfer.payload_size);
     TEST_ASSERT(compareStringWithPayload("It will never cease.", transfer.payload.view));
     // Free the memory.
-    udpardFragmentFree(transfer.payload, &mem_fragment.base, &mem_payload.base);
+    udpardRxFragmentFree(transfer.payload, &mem_fragment.base, &mem_payload.base);
     TEST_ASSERT_EQUAL(2, mem_session.allocated_fragments);  // The sessions remain.
     TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
     TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);
@@ -2234,7 +2234,7 @@ static inline void testPortAcceptFrameA(void)
     TEST_ASSERT_EQUAL(20, transfer.payload_size);
     TEST_ASSERT(compareStringWithPayload("Cheng Xin shuddered.", transfer.payload.view));
     // Free the memory.
-    udpardFragmentFree(transfer.payload, &mem_fragment.base, &mem_payload.base);
+    udpardRxFragmentFree(transfer.payload, &mem_fragment.base, &mem_payload.base);
     TEST_ASSERT_EQUAL(2, mem_session.allocated_fragments);  // The sessions remain.
     TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
     TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);

--- a/tests/src/test_intrusive_rx.c
+++ b/tests/src/test_intrusive_rx.c
@@ -1476,6 +1476,7 @@ static void testIfaceAcceptB(void)
     // === TRANSFER === (x3)
     // Send three interleaving multi-frame out-of-order transfers (primes for duplicates):
     //  A2 B1 A0 C0 B0 A1 C0' C1
+    // A2 arrives before B1 but its timestamp is higher.
     // Transfer B will be evicted by C because by the time C0 arrives, transfer B is the oldest one,
     // since its timestamp is inherited from B0.
     TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);
@@ -1506,7 +1507,7 @@ static void testIfaceAcceptB(void)
     // B1
     TEST_ASSERT_EQUAL(0,
                       rxIfaceAccept(&iface,
-                                    2000000010,                      // Transfer-ID timeout.
+                                    2000000010,                      // TIME REORDERING -- lower than previous.
                                     makeRxFrameString(&mem_payload,  //
                                                       (TransferMetadata){.priority       = UdpardPrioritySlow,
                                                                          .src_node_id    = 2222,

--- a/tests/src/test_intrusive_rx.c
+++ b/tests/src/test_intrusive_rx.c
@@ -180,6 +180,21 @@ static struct UdpardMutablePayload makeDatagramPayloadSingleFrameString(struct U
                                           (struct UdpardPayload){.data = payload, .size = strlen(payload)});
 }
 
+// --------------------------------------------------  MISC  --------------------------------------------------
+
+static void testCompare32(void)
+{
+    TEST_ASSERT_EQUAL(0, compare32(0, 0));
+    TEST_ASSERT_EQUAL(0, compare32(1, 1));
+    TEST_ASSERT_EQUAL(0, compare32(0xdeadbeef, 0xdeadbeef));
+    TEST_ASSERT_EQUAL(0, compare32(0x0badc0de, 0x0badc0de));
+    TEST_ASSERT_EQUAL(0, compare32(0xffffffff, 0xffffffff));
+    TEST_ASSERT_EQUAL(+1, compare32(1, 0));
+    TEST_ASSERT_EQUAL(+1, compare32(0xffffffff, 0xfffffffe));
+    TEST_ASSERT_EQUAL(-1, compare32(0, 1));
+    TEST_ASSERT_EQUAL(-1, compare32(0xfffffffe, 0xffffffff));
+}
+
 // --------------------------------------------------  FRAME PARSING  --------------------------------------------------
 
 // Generate reference data using PyCyphal:
@@ -2364,6 +2379,8 @@ void tearDown(void) {}
 int main(void)
 {
     UNITY_BEGIN();
+    // misc
+    RUN_TEST(testCompare32);
     // frame parser
     RUN_TEST(testParseFrameValidMessage);
     RUN_TEST(testParseFrameValidRPCService);

--- a/tests/src/test_intrusive_rx.c
+++ b/tests/src/test_intrusive_rx.c
@@ -16,7 +16,7 @@
 //  data_specifier=MessageDataSpecifier(7654), user_data=0)
 // >>> list(frame.compile_header_and_payload()[0])
 // [1, 2, 41, 9, 56, 21, 230, 29, 13, 240, 221, 224, 254, 15, 220, 186, 57, 48, 0, 0, 0, 0, 224, 60]
-static void testRxParseFrameValidMessage(void)
+static void testParseFrameValidMessage(void)
 {
     byte_t  data[] = {1,   2,   41,  9,   255, 255, 230, 29, 13, 240, 221, 224,
                       254, 15,  220, 186, 57,  48,  0,   0,  0,  0,   30,  179,  //
@@ -34,7 +34,7 @@ static void testRxParseFrameValidMessage(void)
     TEST_ASSERT_EQUAL_UINT8_ARRAY("abc", rxf.payload.data, 3);
 }
 
-static void testRxParseFrameValidRPCService(void)
+static void testParseFrameValidRPCService(void)
 {
     // frame = UDPFrame(priority=Priority.FAST, transfer_id=0xbadc0ffee0ddf00d, index=6654, end_of_transfer=False,
     // payload=memoryview(b''), source_node_id=2345, destination_node_id=4567,
@@ -57,7 +57,7 @@ static void testRxParseFrameValidRPCService(void)
     TEST_ASSERT_EQUAL_UINT8_ARRAY("abc", rxf.payload.data, 3);
 }
 
-static void testRxParseFrameValidMessageAnonymous(void)
+static void testParseFrameValidMessageAnonymous(void)
 {
     byte_t  data[] = {1,   2,   255, 255, 255, 255, 230, 29,  13, 240, 221, 224,
                       254, 15,  220, 186, 0,   0,   0,   128, 0,  0,   168, 92,  //
@@ -75,7 +75,7 @@ static void testRxParseFrameValidMessageAnonymous(void)
     TEST_ASSERT_EQUAL_UINT8_ARRAY("abc", rxf.payload.data, 3);
 }
 
-static void testRxParseFrameRPCServiceAnonymous(void)
+static void testParseFrameRPCServiceAnonymous(void)
 {
     byte_t  data[] = {1,   2,   255, 255, 215, 17, 123, 192, 13, 240, 221, 224,
                       254, 15,  220, 186, 254, 25, 0,   0,   0,  0,   75,  79,  //
@@ -84,7 +84,7 @@ static void testRxParseFrameRPCServiceAnonymous(void)
     TEST_ASSERT_FALSE(rxParseFrame((struct UdpardMutablePayload){.data = data, .size = sizeof(data)}, &rxf));
 }
 
-static void testRxParseFrameRPCServiceBroadcast(void)
+static void testParseFrameRPCServiceBroadcast(void)
 {
     byte_t  data[] = {1,   2,   41,  9,   255, 255, 123, 192, 13, 240, 221, 224,
                       254, 15,  220, 186, 254, 25,  0,   0,   0,  0,   248, 152,  //
@@ -93,7 +93,7 @@ static void testRxParseFrameRPCServiceBroadcast(void)
     TEST_ASSERT_FALSE(rxParseFrame((struct UdpardMutablePayload){.data = data, .size = sizeof(data)}, &rxf));
 }
 
-static void testRxParseFrameAnonymousNonSingleFrame(void)
+static void testParseFrameAnonymousNonSingleFrame(void)
 {  // Invalid anonymous message frame because EOT not set (multi-frame anonymous transfers are not allowed).
     byte_t  data[] = {1,   2,   255, 255, 255, 255, 230, 29, 13, 240, 221, 224,
                       254, 15,  220, 186, 0,   0,   0,   0,  0,  0,   147, 6,  //
@@ -102,7 +102,7 @@ static void testRxParseFrameAnonymousNonSingleFrame(void)
     TEST_ASSERT_FALSE(rxParseFrame((struct UdpardMutablePayload){.data = data, .size = sizeof(data)}, &rxf));
 }
 
-static void testRxParseFrameBadHeaderCRC(void)
+static void testParseFrameBadHeaderCRC(void)
 {  // Bad header CRC.
     byte_t  data[] = {1,   2,   41,  9,   255, 255, 230, 29, 13, 240, 221, 224,
                       254, 15,  220, 186, 57,  48,  0,   0,  0,  0,   30,  180,  //
@@ -111,7 +111,7 @@ static void testRxParseFrameBadHeaderCRC(void)
     TEST_ASSERT_FALSE(rxParseFrame((struct UdpardMutablePayload){.data = data, .size = sizeof(data)}, &rxf));
 }
 
-static void testRxParseFrameUnknownHeaderVersion(void)
+static void testParseFrameUnknownHeaderVersion(void)
 {
     // >>> from pycyphal.transport.commons.crc import CRC16CCITT
     // >>> list(CRC16CCITT.new(bytes(
@@ -123,17 +123,27 @@ static void testRxParseFrameUnknownHeaderVersion(void)
     TEST_ASSERT_FALSE(rxParseFrame((struct UdpardMutablePayload){.data = data, .size = sizeof(data)}, &rxf));
 }
 
-static void testRxParseFrameHeaderWithoutPayload(void)
+static void testParseFrameHeaderWithoutPayload(void)
 {
     byte_t data[] = {1, 2, 41, 9, 255, 255, 230, 29, 13, 240, 221, 224, 254, 15, 220, 186, 57, 48, 0, 0, 0, 0, 30, 179};
     RxFrame rxf   = {0};
     TEST_ASSERT_FALSE(rxParseFrame((struct UdpardMutablePayload){.data = data, .size = sizeof(data)}, &rxf));
 }
 
-static void testRxParseFrameEmpty(void)
+static void testParseFrameEmpty(void)
 {
     RxFrame rxf = {0};
     TEST_ASSERT_FALSE(rxParseFrame((struct UdpardMutablePayload){.data = "", .size = 0}, &rxf));
+}
+
+static void testSessionSlotRestartEmpty(void)
+{
+    // TODO
+}
+
+static void testSessionSlotRestartNonEmpty(void)
+{
+    // TODO
 }
 
 void setUp(void) {}
@@ -143,15 +153,17 @@ void tearDown(void) {}
 int main(void)
 {
     UNITY_BEGIN();
-    RUN_TEST(testRxParseFrameValidMessage);
-    RUN_TEST(testRxParseFrameValidRPCService);
-    RUN_TEST(testRxParseFrameValidMessageAnonymous);
-    RUN_TEST(testRxParseFrameRPCServiceAnonymous);
-    RUN_TEST(testRxParseFrameRPCServiceBroadcast);
-    RUN_TEST(testRxParseFrameAnonymousNonSingleFrame);
-    RUN_TEST(testRxParseFrameBadHeaderCRC);
-    RUN_TEST(testRxParseFrameUnknownHeaderVersion);
-    RUN_TEST(testRxParseFrameHeaderWithoutPayload);
-    RUN_TEST(testRxParseFrameEmpty);
+    RUN_TEST(testParseFrameValidMessage);
+    RUN_TEST(testParseFrameValidRPCService);
+    RUN_TEST(testParseFrameValidMessageAnonymous);
+    RUN_TEST(testParseFrameRPCServiceAnonymous);
+    RUN_TEST(testParseFrameRPCServiceBroadcast);
+    RUN_TEST(testParseFrameAnonymousNonSingleFrame);
+    RUN_TEST(testParseFrameBadHeaderCRC);
+    RUN_TEST(testParseFrameUnknownHeaderVersion);
+    RUN_TEST(testParseFrameHeaderWithoutPayload);
+    RUN_TEST(testParseFrameEmpty);
+    RUN_TEST(testSessionSlotRestartEmpty);
+    RUN_TEST(testSessionSlotRestartNonEmpty);
     return UNITY_END();
 }

--- a/tests/src/test_intrusive_rx.c
+++ b/tests/src/test_intrusive_rx.c
@@ -1936,8 +1936,8 @@ static void testSessionDeduplicate(void)
     InstrumentedAllocator mem_payload  = {0};
     instrumentedAllocatorNew(&mem_fragment);
     instrumentedAllocatorNew(&mem_payload);
-    const RxMemory          mem     = makeRxMemory(&mem_fragment, &mem_payload);
-    UdpardInternalRxSession session = {0};
+    const RxMemory                 mem     = makeRxMemory(&mem_fragment, &mem_payload);
+    struct UdpardInternalRxSession session = {0};
     rxSessionInit(&session, mem);
     TEST_ASSERT_EQUAL(TIMESTAMP_UNSET, session.last_ts_usec);
     TEST_ASSERT_EQUAL(TRANSFER_ID_UNSET, session.last_transfer_id);
@@ -2029,8 +2029,8 @@ static void testSessionAcceptA(void)
     InstrumentedAllocator mem_payload  = {0};
     instrumentedAllocatorNew(&mem_fragment);
     instrumentedAllocatorNew(&mem_payload);
-    const RxMemory          mem     = makeRxMemory(&mem_fragment, &mem_payload);
-    UdpardInternalRxSession session = {0};
+    const RxMemory                 mem     = makeRxMemory(&mem_fragment, &mem_payload);
+    struct UdpardInternalRxSession session = {0};
     rxSessionInit(&session, mem);
     TEST_ASSERT_EQUAL(TIMESTAMP_UNSET, session.last_ts_usec);
     TEST_ASSERT_EQUAL(TRANSFER_ID_UNSET, session.last_transfer_id);
@@ -2363,7 +2363,7 @@ static inline void testPortAcceptFrameA(void)
     TEST_ASSERT_EQUAL(4, mem_session.allocated_fragments);  // New source.
     TEST_ASSERT_EQUAL(3, mem_fragment.allocated_fragments);
     TEST_ASSERT_EQUAL(3, mem_payload.allocated_fragments);
-    TEST_ASSERT_EQUAL(4 * sizeof(UdpardInternalRxSession), mem_session.allocated_bytes);
+    TEST_ASSERT_EQUAL(4 * sizeof(struct UdpardInternalRxSession), mem_session.allocated_bytes);
     TEST_ASSERT_EQUAL(3 * sizeof(RxFragment), mem_fragment.allocated_bytes);
 
     // Free the port instance and ensure all ifaces and sessions are cleaned up.

--- a/tests/src/test_intrusive_rx.c
+++ b/tests/src/test_intrusive_rx.c
@@ -7,6 +7,8 @@
 #include "helpers.h"
 #include <unity.h>
 
+// NOLINTBEGIN(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
+
 // Generate reference data using PyCyphal:
 //
 // >>> from pycyphal.transport.udp import UDPFrame
@@ -32,6 +34,8 @@ static void testParseFrameValidMessage(void)
     TEST_ASSERT_FALSE(rxf.end_of_transfer);
     TEST_ASSERT_EQUAL_UINT64(3, rxf.payload.size);
     TEST_ASSERT_EQUAL_UINT8_ARRAY("abc", rxf.payload.data, 3);
+    TEST_ASSERT_EQUAL_UINT64(sizeof(data), rxf.origin.size);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(data, rxf.origin.data, sizeof(data));
 }
 
 static void testParseFrameValidRPCService(void)
@@ -55,6 +59,8 @@ static void testParseFrameValidRPCService(void)
     TEST_ASSERT_FALSE(rxf.end_of_transfer);
     TEST_ASSERT_EQUAL_UINT64(3, rxf.payload.size);
     TEST_ASSERT_EQUAL_UINT8_ARRAY("abc", rxf.payload.data, 3);
+    TEST_ASSERT_EQUAL_UINT64(sizeof(data), rxf.origin.size);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(data, rxf.origin.data, sizeof(data));
 }
 
 static void testParseFrameValidMessageAnonymous(void)
@@ -73,6 +79,8 @@ static void testParseFrameValidMessageAnonymous(void)
     TEST_ASSERT_TRUE(rxf.end_of_transfer);
     TEST_ASSERT_EQUAL_UINT64(3, rxf.payload.size);
     TEST_ASSERT_EQUAL_UINT8_ARRAY("abc", rxf.payload.data, 3);
+    TEST_ASSERT_EQUAL_UINT64(sizeof(data), rxf.origin.size);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(data, rxf.origin.data, sizeof(data));
 }
 
 static void testParseFrameRPCServiceAnonymous(void)
@@ -136,12 +144,123 @@ static void testParseFrameEmpty(void)
     TEST_ASSERT_FALSE(rxParseFrame((struct UdpardMutablePayload){.data = "", .size = 0}, &rxf));
 }
 
-static void testSessionSlotRestartEmpty(void)
+/// Moves the payload from the origin into a new buffer and attaches is to the newly allocated fragment.
+/// This function performs two allocations. This function is infallible.
+static RxFragment* makeRxFragment(struct UdpardMemoryResource* const memory_fragment,
+                                  struct UdpardMemoryResource* const memory_payload,
+                                  const uint32_t                     frame_index,
+                                  const struct UdpardPayload         view,
+                                  const struct UdpardMutablePayload  origin,
+                                  RxFragmentTreeNode* const          parent)
 {
-    // TODO
+    TEST_PANIC_UNLESS((view.data >= origin.data) && (view.size <= origin.size));
+    TEST_PANIC_UNLESS((((const byte_t*) view.data) + view.size) <= (((const byte_t*) origin.data) + origin.size));
+    byte_t* const     new_origin = (byte_t*) memAlloc(memory_payload, origin.size);
+    RxFragment* const frag       = (RxFragment*) memAlloc(memory_fragment, sizeof(RxFragment));
+    if ((new_origin != NULL) && (frag != NULL))
+    {
+        (void) memmove(new_origin, origin.data, origin.size);
+        (void) memset(frag, 0, sizeof(RxFragment));
+        frag->tree.base.lr[0]  = NULL;
+        frag->tree.base.lr[1]  = NULL;
+        frag->tree.base.up     = &parent->base;
+        frag->tree.this        = frag;
+        frag->frame_index      = frame_index;
+        frag->base.view        = view;
+        frag->base.origin.data = new_origin;
+        frag->base.origin.size = origin.size;
+        frag->base.view.data   = new_origin + (((const byte_t*) view.data) - ((byte_t*) origin.data));
+        frag->base.view.size   = view.size;
+    }
+    else
+    {
+        TEST_PANIC("Failed to allocate RxFragment");
+    }
+    return frag;
 }
 
-static void testSessionSlotRestartNonEmpty(void)
+static void testSlotRestartEmpty(void)
+{
+    RxSlot slot = {
+        .ts_usec         = 1234567890,
+        .transfer_id     = 0x123456789abcdef0,
+        .max_index       = 546,
+        .eot_index       = 654,
+        .accepted_frames = 555,
+        .payload_size    = 987,
+        .fragments       = NULL,
+    };
+    InstrumentedAllocator alloc = {0};
+    rxSlotRestart(&slot, 0x1122334455667788ULL, &alloc.base, &alloc.base);
+    TEST_ASSERT_EQUAL(TIMESTAMP_UNSET, slot.ts_usec);
+    TEST_ASSERT_EQUAL(0x1122334455667788ULL, slot.transfer_id);
+    TEST_ASSERT_EQUAL(0, slot.max_index);
+    TEST_ASSERT_EQUAL(FRAME_INDEX_UNSET, slot.eot_index);
+    TEST_ASSERT_EQUAL(0, slot.accepted_frames);
+    TEST_ASSERT_EQUAL(0, slot.payload_size);
+    TEST_ASSERT_EQUAL(NULL, slot.fragments);
+}
+
+static void testSlotRestartNonEmpty(void)
+{
+    InstrumentedAllocator mem_fragment = {0};
+    InstrumentedAllocator mem_payload  = {0};
+    instrumentedAllocatorNew(&mem_fragment);
+    instrumentedAllocatorNew(&mem_payload);
+    byte_t data[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    //
+    RxSlot slot = {
+        .ts_usec         = 1234567890,
+        .transfer_id     = 0x123456789abcdef0,
+        .max_index       = 546,
+        .eot_index       = 654,
+        .accepted_frames = 555,
+        .payload_size    = 987,
+        //
+        .fragments = &makeRxFragment(&mem_fragment.base,
+                                     &mem_payload.base,
+                                     1,
+                                     (struct UdpardPayload){.data = &data[2], .size = 2},
+                                     (struct UdpardMutablePayload){.data = data, .size = sizeof(data)},
+                                     NULL)
+                          ->tree,
+    };
+    slot.fragments->base.lr[0] = &makeRxFragment(&mem_fragment.base,
+                                                 &mem_payload.base,
+                                                 0,
+                                                 (struct UdpardPayload){.data = &data[1], .size = 1},
+                                                 (struct UdpardMutablePayload){.data = data, .size = sizeof(data)},
+                                                 slot.fragments)
+                                      ->tree.base;
+    slot.fragments->base.lr[1] = &makeRxFragment(&mem_fragment.base,
+                                                 &mem_payload.base,
+                                                 2,
+                                                 (struct UdpardPayload){.data = &data[3], .size = 3},
+                                                 (struct UdpardMutablePayload){.data = data, .size = sizeof(data)},
+                                                 slot.fragments)
+                                      ->tree.base;
+    // Initialization done, ensure the memory utilization is as we expect.
+    TEST_ASSERT_EQUAL(3, mem_payload.allocated_fragments);
+    TEST_ASSERT_EQUAL(sizeof(data) * 3, mem_payload.allocated_bytes);
+    TEST_ASSERT_EQUAL(3, mem_fragment.allocated_fragments);
+    TEST_ASSERT_EQUAL(sizeof(RxFragment) * 3, mem_fragment.allocated_bytes);
+    // Now we reset the slot, causing all memory to be freed correctly.
+    rxSlotRestart(&slot, 0x1122334455667788ULL, &mem_fragment.base, &mem_payload.base);
+    TEST_ASSERT_EQUAL(TIMESTAMP_UNSET, slot.ts_usec);
+    TEST_ASSERT_EQUAL(0x1122334455667788ULL, slot.transfer_id);
+    TEST_ASSERT_EQUAL(0, slot.max_index);
+    TEST_ASSERT_EQUAL(FRAME_INDEX_UNSET, slot.eot_index);
+    TEST_ASSERT_EQUAL(0, slot.accepted_frames);
+    TEST_ASSERT_EQUAL(0, slot.payload_size);
+    TEST_ASSERT_EQUAL(NULL, slot.fragments);
+    // Ensure all memory was freed.
+    TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_payload.allocated_bytes);
+    TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_fragment.allocated_bytes);
+}
+
+static void testSlotEject(void)
 {
     // TODO
 }
@@ -163,7 +282,10 @@ int main(void)
     RUN_TEST(testParseFrameUnknownHeaderVersion);
     RUN_TEST(testParseFrameHeaderWithoutPayload);
     RUN_TEST(testParseFrameEmpty);
-    RUN_TEST(testSessionSlotRestartEmpty);
-    RUN_TEST(testSessionSlotRestartNonEmpty);
+    RUN_TEST(testSlotRestartEmpty);
+    RUN_TEST(testSlotRestartNonEmpty);
+    RUN_TEST(testSlotEject);
     return UNITY_END();
 }
+
+// NOLINTEND(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)

--- a/tests/src/test_intrusive_rx.c
+++ b/tests/src/test_intrusive_rx.c
@@ -122,7 +122,7 @@ static RxMemory makeRxMemory(InstrumentedAllocator* const fragment, Instrumented
     return (RxMemory){.fragment = &fragment->base, .payload = &payload->base};
 }
 
-// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------  FRAME PARSE  --------------------------------------------------
 
 // Generate reference data using PyCyphal:
 //
@@ -258,6 +258,8 @@ static void testParseFrameEmpty(void)
     RxFrame rxf = {0};
     TEST_ASSERT_FALSE(rxParseFrame((struct UdpardMutablePayload){.data = "", .size = 0}, &rxf));
 }
+
+// --------------------------------------------------  SLOT  --------------------------------------------------
 
 static void testSlotRestartEmpty(void)
 {
@@ -955,6 +957,8 @@ static void testSlotAcceptA(void)
     TEST_ASSERT_EQUAL(0, slot.payload_size);
     TEST_ASSERT_NULL(slot.fragments);
 }
+
+// --------------------------------------------------  IFACE  --------------------------------------------------
 
 static void testIfaceIsFutureTransferID(void)
 {
@@ -1850,6 +1854,8 @@ static void testIfaceAcceptC(void)
     TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
 }
 
+// --------------------------------------------------  SESSION  --------------------------------------------------
+
 static void testSessionDeduplicate(void)
 {
     InstrumentedAllocator mem_fragment = {0};
@@ -2022,6 +2028,15 @@ static void testSessionAcceptA(void)
     TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
 }
 
+// --------------------------------------------------  PORT  --------------------------------------------------
+
+static inline void testPortAcceptFrameA(void)
+{
+    //
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
 void setUp(void) {}
 
 void tearDown(void) {}
@@ -2058,6 +2073,8 @@ int main(void)
     // session
     RUN_TEST(testSessionDeduplicate);
     RUN_TEST(testSessionAcceptA);
+    // port
+    RUN_TEST(testPortAcceptFrameA);
     return UNITY_END();
 }
 

--- a/tests/src/test_intrusive_rx.c
+++ b/tests/src/test_intrusive_rx.c
@@ -18,11 +18,11 @@
 // [1, 2, 41, 9, 56, 21, 230, 29, 13, 240, 221, 224, 254, 15, 220, 186, 57, 48, 0, 0, 0, 0, 224, 60]
 static void testRxParseFrameValidMessage(void)
 {
-    const byte_t data[] = {1,   2,   41,  9,   255, 255, 230, 29, 13, 240, 221, 224,
-                           254, 15,  220, 186, 57,  48,  0,   0,  0,  0,   30,  179,  //
-                           'a', 'b', 'c'};
-    RxFrame      rxf    = {0};
-    TEST_ASSERT(rxParseFrame((struct UdpardConstPayload){.data = data, .size = sizeof(data)}, &rxf));
+    byte_t  data[] = {1,   2,   41,  9,   255, 255, 230, 29, 13, 240, 221, 224,
+                      254, 15,  220, 186, 57,  48,  0,   0,  0,  0,   30,  179,  //
+                      'a', 'b', 'c'};
+    RxFrame rxf    = {0};
+    TEST_ASSERT(rxParseFrame((struct UdpardMutablePayload){.data = data, .size = sizeof(data)}, &rxf));
     TEST_ASSERT_EQUAL_UINT64(UdpardPriorityFast, rxf.meta.priority);
     TEST_ASSERT_EQUAL_UINT64(2345, rxf.meta.src_node_id);
     TEST_ASSERT_EQUAL_UINT64(UDPARD_NODE_ID_UNSET, rxf.meta.dst_node_id);
@@ -39,11 +39,11 @@ static void testRxParseFrameValidRPCService(void)
     // frame = UDPFrame(priority=Priority.FAST, transfer_id=0xbadc0ffee0ddf00d, index=6654, end_of_transfer=False,
     // payload=memoryview(b''), source_node_id=2345, destination_node_id=4567,
     // data_specifier=ServiceDataSpecifier(role=ServiceDataSpecifier.Role.REQUEST, service_id=123), user_data=0)
-    const byte_t data[] = {1,   2,   41,  9,   215, 17, 123, 192, 13, 240, 221, 224,
-                           254, 15,  220, 186, 254, 25, 0,   0,   0,  0,   173, 122,  //
-                           'a', 'b', 'c'};
-    RxFrame      rxf    = {0};
-    TEST_ASSERT(rxParseFrame((struct UdpardConstPayload){.data = data, .size = sizeof(data)}, &rxf));
+    byte_t  data[] = {1,   2,   41,  9,   215, 17, 123, 192, 13, 240, 221, 224,
+                      254, 15,  220, 186, 254, 25, 0,   0,   0,  0,   173, 122,  //
+                      'a', 'b', 'c'};
+    RxFrame rxf    = {0};
+    TEST_ASSERT(rxParseFrame((struct UdpardMutablePayload){.data = data, .size = sizeof(data)}, &rxf));
     TEST_ASSERT_EQUAL_UINT64(UdpardPriorityFast, rxf.meta.priority);
     TEST_ASSERT_EQUAL_UINT64(2345, rxf.meta.src_node_id);
     TEST_ASSERT_EQUAL_UINT64(4567, rxf.meta.dst_node_id);
@@ -59,11 +59,11 @@ static void testRxParseFrameValidRPCService(void)
 
 static void testRxParseFrameValidMessageAnonymous(void)
 {
-    const byte_t data[] = {1,   2,   255, 255, 255, 255, 230, 29,  13, 240, 221, 224,
-                           254, 15,  220, 186, 0,   0,   0,   128, 0,  0,   168, 92,  //
-                           'a', 'b', 'c'};
-    RxFrame      rxf    = {0};
-    TEST_ASSERT(rxParseFrame((struct UdpardConstPayload){.data = data, .size = sizeof(data)}, &rxf));
+    byte_t  data[] = {1,   2,   255, 255, 255, 255, 230, 29,  13, 240, 221, 224,
+                      254, 15,  220, 186, 0,   0,   0,   128, 0,  0,   168, 92,  //
+                      'a', 'b', 'c'};
+    RxFrame rxf    = {0};
+    TEST_ASSERT(rxParseFrame((struct UdpardMutablePayload){.data = data, .size = sizeof(data)}, &rxf));
     TEST_ASSERT_EQUAL_UINT64(UdpardPriorityFast, rxf.meta.priority);
     TEST_ASSERT_EQUAL_UINT64(UDPARD_NODE_ID_UNSET, rxf.meta.src_node_id);
     TEST_ASSERT_EQUAL_UINT64(UDPARD_NODE_ID_UNSET, rxf.meta.dst_node_id);
@@ -77,38 +77,38 @@ static void testRxParseFrameValidMessageAnonymous(void)
 
 static void testRxParseFrameRPCServiceAnonymous(void)
 {
-    const byte_t data[] = {1,   2,   255, 255, 215, 17, 123, 192, 13, 240, 221, 224,
-                           254, 15,  220, 186, 254, 25, 0,   0,   0,  0,   75,  79,  //
-                           'a', 'b', 'c'};
-    RxFrame      rxf    = {0};
-    TEST_ASSERT_FALSE(rxParseFrame((struct UdpardConstPayload){.data = data, .size = sizeof(data)}, &rxf));
+    byte_t  data[] = {1,   2,   255, 255, 215, 17, 123, 192, 13, 240, 221, 224,
+                      254, 15,  220, 186, 254, 25, 0,   0,   0,  0,   75,  79,  //
+                      'a', 'b', 'c'};
+    RxFrame rxf    = {0};
+    TEST_ASSERT_FALSE(rxParseFrame((struct UdpardMutablePayload){.data = data, .size = sizeof(data)}, &rxf));
 }
 
 static void testRxParseFrameRPCServiceBroadcast(void)
 {
-    const byte_t data[] = {1,   2,   41,  9,   255, 255, 123, 192, 13, 240, 221, 224,
-                           254, 15,  220, 186, 254, 25,  0,   0,   0,  0,   248, 152,  //
-                           'a', 'b', 'c'};
-    RxFrame      rxf    = {0};
-    TEST_ASSERT_FALSE(rxParseFrame((struct UdpardConstPayload){.data = data, .size = sizeof(data)}, &rxf));
+    byte_t  data[] = {1,   2,   41,  9,   255, 255, 123, 192, 13, 240, 221, 224,
+                      254, 15,  220, 186, 254, 25,  0,   0,   0,  0,   248, 152,  //
+                      'a', 'b', 'c'};
+    RxFrame rxf    = {0};
+    TEST_ASSERT_FALSE(rxParseFrame((struct UdpardMutablePayload){.data = data, .size = sizeof(data)}, &rxf));
 }
 
 static void testRxParseFrameAnonymousNonSingleFrame(void)
 {  // Invalid anonymous message frame because EOT not set (multi-frame anonymous transfers are not allowed).
-    const byte_t data[] = {1,   2,   255, 255, 255, 255, 230, 29, 13, 240, 221, 224,
-                           254, 15,  220, 186, 0,   0,   0,   0,  0,  0,   147, 6,  //
-                           'a', 'b', 'c'};
-    RxFrame      rxf    = {0};
-    TEST_ASSERT_FALSE(rxParseFrame((struct UdpardConstPayload){.data = data, .size = sizeof(data)}, &rxf));
+    byte_t  data[] = {1,   2,   255, 255, 255, 255, 230, 29, 13, 240, 221, 224,
+                      254, 15,  220, 186, 0,   0,   0,   0,  0,  0,   147, 6,  //
+                      'a', 'b', 'c'};
+    RxFrame rxf    = {0};
+    TEST_ASSERT_FALSE(rxParseFrame((struct UdpardMutablePayload){.data = data, .size = sizeof(data)}, &rxf));
 }
 
 static void testRxParseFrameBadHeaderCRC(void)
 {  // Bad header CRC.
-    const byte_t data[] = {1,   2,   41,  9,   255, 255, 230, 29, 13, 240, 221, 224,
-                           254, 15,  220, 186, 57,  48,  0,   0,  0,  0,   30,  180,  //
-                           'a', 'b', 'c'};
-    RxFrame      rxf    = {0};
-    TEST_ASSERT_FALSE(rxParseFrame((struct UdpardConstPayload){.data = data, .size = sizeof(data)}, &rxf));
+    byte_t  data[] = {1,   2,   41,  9,   255, 255, 230, 29, 13, 240, 221, 224,
+                      254, 15,  220, 186, 57,  48,  0,   0,  0,  0,   30,  180,  //
+                      'a', 'b', 'c'};
+    RxFrame rxf    = {0};
+    TEST_ASSERT_FALSE(rxParseFrame((struct UdpardMutablePayload){.data = data, .size = sizeof(data)}, &rxf));
 }
 
 static void testRxParseFrameUnknownHeaderVersion(void)
@@ -116,25 +116,24 @@ static void testRxParseFrameUnknownHeaderVersion(void)
     // >>> from pycyphal.transport.commons.crc import CRC16CCITT
     // >>> list(CRC16CCITT.new(bytes(
     //    [0, 2, 41, 9, 56, 21, 230, 29, 13, 240, 221, 224, 254, 15, 220, 186, 57, 48, 0, 0, 0, 0])).value_as_bytes)
-    const byte_t data[] = {0,   2,   41,  9,   56, 21, 230, 29, 13, 240, 221, 224,
-                           254, 15,  220, 186, 57, 48, 0,   0,  0,  0,   141, 228,  //
-                           'a', 'b', 'c'};
-    RxFrame      rxf    = {0};
-    TEST_ASSERT_FALSE(rxParseFrame((struct UdpardConstPayload){.data = data, .size = sizeof(data)}, &rxf));
+    byte_t  data[] = {0,   2,   41,  9,   56, 21, 230, 29, 13, 240, 221, 224,
+                      254, 15,  220, 186, 57, 48, 0,   0,  0,  0,   141, 228,  //
+                      'a', 'b', 'c'};
+    RxFrame rxf    = {0};
+    TEST_ASSERT_FALSE(rxParseFrame((struct UdpardMutablePayload){.data = data, .size = sizeof(data)}, &rxf));
 }
 
 static void testRxParseFrameHeaderWithoutPayload(void)
 {
-    const byte_t data[] = {1,   2,  41,  9,   255, 255, 230, 29, 13, 240, 221, 224,
-                           254, 15, 220, 186, 57,  48,  0,   0,  0,  0,   30,  179};
-    RxFrame      rxf    = {0};
-    TEST_ASSERT_FALSE(rxParseFrame((struct UdpardConstPayload){.data = data, .size = sizeof(data)}, &rxf));
+    byte_t data[] = {1, 2, 41, 9, 255, 255, 230, 29, 13, 240, 221, 224, 254, 15, 220, 186, 57, 48, 0, 0, 0, 0, 30, 179};
+    RxFrame rxf   = {0};
+    TEST_ASSERT_FALSE(rxParseFrame((struct UdpardMutablePayload){.data = data, .size = sizeof(data)}, &rxf));
 }
 
 static void testRxParseFrameEmpty(void)
 {
     RxFrame rxf = {0};
-    TEST_ASSERT_FALSE(rxParseFrame((struct UdpardConstPayload){.data = "", .size = 0}, &rxf));
+    TEST_ASSERT_FALSE(rxParseFrame((struct UdpardMutablePayload){.data = "", .size = 0}, &rxf));
 }
 
 void setUp(void) {}

--- a/tests/src/test_intrusive_tx.c
+++ b/tests/src/test_intrusive_tx.c
@@ -26,7 +26,7 @@ static const size_t InterstellarWarSize   = sizeof(InterstellarWar) - 1;
 static const byte_t InterstellarWarCRC[4] = {102, 217, 109, 188};
 
 // These aliases cannot be defined in the public API section: https://github.com/OpenCyphal-Garage/libudpard/issues/36
-typedef struct UdpardConstPayload  UdpardConstPayload;
+typedef struct UdpardPayload       UdpardPayload;
 typedef struct UdpardUDPIPEndpoint UdpardUDPIPEndpoint;
 typedef struct UdpardTx            UdpardTx;
 typedef struct UdpardTxItem        UdpardTxItem;
@@ -108,7 +108,7 @@ static void testMakeChainEmpty(void)
                                       1234567890,
                                       meta,
                                       (UdpardUDPIPEndpoint){.ip_address = 0x0A0B0C0DU, .udp_port = 0x1234},
-                                      (UdpardConstPayload){.size = 0, .data = ""},
+                                      (UdpardPayload){.size = 0, .data = ""},
                                       &user_transfer_referent);
     TEST_ASSERT_EQUAL(1, alloc.allocated_fragments);
     TEST_ASSERT_EQUAL(sizeof(TxItem) + HEADER_SIZE_BYTES + 4, alloc.allocated_bytes);
@@ -151,7 +151,7 @@ static void testMakeChainSingleMaxMTU(void)
                                       1234567890,
                                       meta,
                                       (UdpardUDPIPEndpoint){.ip_address = 0x0A0B0C00U, .udp_port = 7474},
-                                      (UdpardConstPayload){.size = DetailOfTheCosmosSize, .data = DetailOfTheCosmos},
+                                      (UdpardPayload){.size = DetailOfTheCosmosSize, .data = DetailOfTheCosmos},
                                       &user_transfer_referent);
     TEST_ASSERT_EQUAL(1, alloc.allocated_fragments);
     TEST_ASSERT_EQUAL(sizeof(TxItem) + HEADER_SIZE_BYTES + DetailOfTheCosmosSize + TRANSFER_CRC_SIZE_BYTES,
@@ -191,19 +191,18 @@ static void testMakeChainSingleFrameDefaultMTU(void)
     instrumentedAllocatorNew(&alloc);
     const byte_t payload[UDPARD_MTU_DEFAULT_MAX_SINGLE_FRAME + 1] = {0};
     {  // Ensure UDPARD_MTU_DEFAULT_MAX_SINGLE_FRAME bytes fit in a single frame with the default MTU.
-        const TxChain chain =
-            txMakeChain(&alloc.base,
-                        (byte_t[]){11, 22, 33, 44, 55, 66, 77, 88},
-                        UDPARD_MTU_DEFAULT,
-                        1234567890,
-                        (TransferMetadata){.priority       = UdpardPrioritySlow,
-                                           .src_node_id    = 4321,
-                                           .dst_node_id    = 5432,
-                                           .data_specifier = 7766,
-                                           .transfer_id    = 0x0123456789ABCDEFULL},
-                        (UdpardUDPIPEndpoint){.ip_address = 0x0A0B0C00U, .udp_port = 7474},
-                        (UdpardConstPayload){.size = UDPARD_MTU_DEFAULT_MAX_SINGLE_FRAME, .data = payload},
-                        NULL);
+        const TxChain chain = txMakeChain(&alloc.base,
+                                          (byte_t[]){11, 22, 33, 44, 55, 66, 77, 88},
+                                          UDPARD_MTU_DEFAULT,
+                                          1234567890,
+                                          (TransferMetadata){.priority       = UdpardPrioritySlow,
+                                                             .src_node_id    = 4321,
+                                                             .dst_node_id    = 5432,
+                                                             .data_specifier = 7766,
+                                                             .transfer_id    = 0x0123456789ABCDEFULL},
+                                          (UdpardUDPIPEndpoint){.ip_address = 0x0A0B0C00U, .udp_port = 7474},
+                                          (UdpardPayload){.size = UDPARD_MTU_DEFAULT_MAX_SINGLE_FRAME, .data = payload},
+                                          NULL);
         TEST_ASSERT_EQUAL(1, alloc.allocated_fragments);
         TEST_ASSERT_EQUAL(sizeof(TxItem) + HEADER_SIZE_BYTES + UDPARD_MTU_DEFAULT_MAX_SINGLE_FRAME +
                               TRANSFER_CRC_SIZE_BYTES,
@@ -229,7 +228,7 @@ static void testMakeChainSingleFrameDefaultMTU(void)
                                            .data_specifier = 7766,
                                            .transfer_id    = 0x0123456789ABCDEFULL},
                         (UdpardUDPIPEndpoint){.ip_address = 0x0A0B0C00U, .udp_port = 7474},
-                        (UdpardConstPayload){.size = UDPARD_MTU_DEFAULT_MAX_SINGLE_FRAME + 1, .data = payload},
+                        (UdpardPayload){.size = UDPARD_MTU_DEFAULT_MAX_SINGLE_FRAME + 1, .data = payload},
                         NULL);
         TEST_ASSERT_EQUAL(2, alloc.allocated_fragments);
         TEST_ASSERT_EQUAL((sizeof(TxItem) + HEADER_SIZE_BYTES) * 2 + UDPARD_MTU_DEFAULT_MAX_SINGLE_FRAME + 1 +
@@ -264,7 +263,7 @@ static void testMakeChainThreeFrames(void)
                                       223574680,
                                       meta,
                                       (UdpardUDPIPEndpoint){.ip_address = 0xBABADEDAU, .udp_port = 0xD0ED},
-                                      (UdpardConstPayload){.size = EtherealStrengthSize, .data = EtherealStrength},
+                                      (UdpardPayload){.size = EtherealStrengthSize, .data = EtherealStrength},
                                       &user_transfer_referent);
     TEST_ASSERT_EQUAL(3, alloc.allocated_fragments);
     TEST_ASSERT_EQUAL(3 * (sizeof(TxItem) + HEADER_SIZE_BYTES) + EtherealStrengthSize + 4U, alloc.allocated_bytes);
@@ -345,7 +344,7 @@ static void testMakeChainCRCSpill1(void)
                                       223574680,
                                       meta,
                                       (UdpardUDPIPEndpoint){.ip_address = 0xBABADEDAU, .udp_port = 0xD0ED},
-                                      (UdpardConstPayload){.size = InterstellarWarSize, .data = InterstellarWar},
+                                      (UdpardPayload){.size = InterstellarWarSize, .data = InterstellarWar},
                                       &user_transfer_referent);
     TEST_ASSERT_EQUAL(2, alloc.allocated_fragments);
     TEST_ASSERT_EQUAL(2 * (sizeof(TxItem) + HEADER_SIZE_BYTES) + InterstellarWarSize + 4U, alloc.allocated_bytes);
@@ -416,7 +415,7 @@ static void testMakeChainCRCSpill2(void)
                                       223574680,
                                       meta,
                                       (UdpardUDPIPEndpoint){.ip_address = 0xBABADEDAU, .udp_port = 0xD0ED},
-                                      (UdpardConstPayload){.size = InterstellarWarSize, .data = InterstellarWar},
+                                      (UdpardPayload){.size = InterstellarWarSize, .data = InterstellarWar},
                                       &user_transfer_referent);
     TEST_ASSERT_EQUAL(2, alloc.allocated_fragments);
     TEST_ASSERT_EQUAL(2 * (sizeof(TxItem) + HEADER_SIZE_BYTES) + InterstellarWarSize + 4U, alloc.allocated_bytes);
@@ -487,7 +486,7 @@ static void testMakeChainCRCSpill3(void)
                                       223574680,
                                       meta,
                                       (UdpardUDPIPEndpoint){.ip_address = 0xBABADEDAU, .udp_port = 0xD0ED},
-                                      (UdpardConstPayload){.size = InterstellarWarSize, .data = InterstellarWar},
+                                      (UdpardPayload){.size = InterstellarWarSize, .data = InterstellarWar},
                                       &user_transfer_referent);
     TEST_ASSERT_EQUAL(2, alloc.allocated_fragments);
     TEST_ASSERT_EQUAL(2 * (sizeof(TxItem) + HEADER_SIZE_BYTES) + InterstellarWarSize + 4U, alloc.allocated_bytes);
@@ -558,7 +557,7 @@ static void testMakeChainCRCSpillFull(void)
                                       223574680,
                                       meta,
                                       (UdpardUDPIPEndpoint){.ip_address = 0xBABADEDAU, .udp_port = 0xD0ED},
-                                      (UdpardConstPayload){.size = InterstellarWarSize, .data = InterstellarWar},
+                                      (UdpardPayload){.size = InterstellarWarSize, .data = InterstellarWar},
                                       &user_transfer_referent);
     TEST_ASSERT_EQUAL(2, alloc.allocated_fragments);
     TEST_ASSERT_EQUAL(2 * (sizeof(TxItem) + HEADER_SIZE_BYTES) + InterstellarWarSize + 4U, alloc.allocated_bytes);
@@ -634,7 +633,7 @@ static void testPushPeekPopFree(void)
                              1234567890U,
                              meta,
                              (UdpardUDPIPEndpoint){.ip_address = 0xBABADEDAU, .udp_port = 0xD0ED},
-                             (UdpardConstPayload){.size = EtherealStrengthSize, .data = EtherealStrength},
+                             (UdpardPayload){.size = EtherealStrengthSize, .data = EtherealStrength},
                              &user_transfer_referent));
     TEST_ASSERT_EQUAL(3, alloc.allocated_fragments);
     TEST_ASSERT_EQUAL(3 * (sizeof(TxItem) + HEADER_SIZE_BYTES) + EtherealStrengthSize + 4U, alloc.allocated_bytes);
@@ -712,7 +711,7 @@ static void testPushPrioritization(void)
                              0,
                              meta_a,
                              (UdpardUDPIPEndpoint){.ip_address = 0xAAAAAAAA, .udp_port = 0xAAAA},
-                             (UdpardConstPayload){.size = EtherealStrengthSize, .data = EtherealStrength},
+                             (UdpardPayload){.size = EtherealStrengthSize, .data = EtherealStrength},
                              NULL));
     TEST_ASSERT_EQUAL(3, alloc.allocated_fragments);
     TEST_ASSERT_EQUAL(3, tx.queue_size);
@@ -732,7 +731,7 @@ static void testPushPrioritization(void)
                                  .transfer_id    = 100000,
                              },
                              (UdpardUDPIPEndpoint){.ip_address = 0xBBBBBBBB, .udp_port = 0xBBBB},
-                             (UdpardConstPayload){.size = DetailOfTheCosmosSize, .data = DetailOfTheCosmos},
+                             (UdpardPayload){.size = DetailOfTheCosmosSize, .data = DetailOfTheCosmos},
                              NULL));
     TEST_ASSERT_EQUAL(4, alloc.allocated_fragments);
     TEST_ASSERT_EQUAL(4, tx.queue_size);
@@ -752,7 +751,7 @@ static void testPushPrioritization(void)
                                  .transfer_id    = 10000,
                              },
                              (UdpardUDPIPEndpoint){.ip_address = 0xCCCCCCCC, .udp_port = 0xCCCC},
-                             (UdpardConstPayload){.size = InterstellarWarSize, .data = InterstellarWar},
+                             (UdpardPayload){.size = InterstellarWarSize, .data = InterstellarWar},
                              NULL));
     TEST_ASSERT_EQUAL(5, alloc.allocated_fragments);
     TEST_ASSERT_EQUAL(5, tx.queue_size);
@@ -772,7 +771,7 @@ static void testPushPrioritization(void)
                                  .transfer_id    = 10001,
                              },
                              (UdpardUDPIPEndpoint){.ip_address = 0xDDDDDDDD, .udp_port = 0xDDDD},
-                             (UdpardConstPayload){.size = InterstellarWarSize, .data = InterstellarWar},
+                             (UdpardPayload){.size = InterstellarWarSize, .data = InterstellarWar},
                              NULL));
     TEST_ASSERT_EQUAL(6, alloc.allocated_fragments);
     TEST_ASSERT_EQUAL(6, tx.queue_size);
@@ -792,7 +791,7 @@ static void testPushPrioritization(void)
                                  .transfer_id    = 1000,
                              },
                              (UdpardUDPIPEndpoint){.ip_address = 0xEEEEEEEE, .udp_port = 0xEEEE},
-                             (UdpardConstPayload){.size = InterstellarWarSize, .data = InterstellarWar},
+                             (UdpardPayload){.size = InterstellarWarSize, .data = InterstellarWar},
                              NULL));
     TEST_ASSERT_EQUAL(7, alloc.allocated_fragments);
     TEST_ASSERT_EQUAL(7, tx.queue_size);
@@ -881,7 +880,7 @@ static void testPushCapacityLimit(void)
                              1234567890U,
                              meta,
                              (UdpardUDPIPEndpoint){.ip_address = 0xBABADEDAU, .udp_port = 0xD0ED},
-                             (UdpardConstPayload){.size = EtherealStrengthSize, .data = EtherealStrength},
+                             (UdpardPayload){.size = EtherealStrengthSize, .data = EtherealStrength},
                              NULL));
     TEST_ASSERT_EQUAL(0, alloc.allocated_fragments);
     TEST_ASSERT_EQUAL(0, alloc.allocated_bytes);
@@ -916,7 +915,7 @@ static void testPushOOM(void)
                              1234567890U,
                              meta,
                              (UdpardUDPIPEndpoint){.ip_address = 0xBABADEDAU, .udp_port = 0xD0ED},
-                             (UdpardConstPayload){.size = EtherealStrengthSize, .data = EtherealStrength},
+                             (UdpardPayload){.size = EtherealStrengthSize, .data = EtherealStrength},
                              NULL));
     TEST_ASSERT_EQUAL(0, alloc.allocated_fragments);
     TEST_ASSERT_EQUAL(0, alloc.allocated_bytes);
@@ -950,7 +949,7 @@ static void testPushAnonymousMultiFrame(void)
                              1234567890U,
                              meta,
                              (UdpardUDPIPEndpoint){.ip_address = 0xBABADEDAU, .udp_port = 0xD0ED},
-                             (UdpardConstPayload){.size = EtherealStrengthSize, .data = EtherealStrength},
+                             (UdpardPayload){.size = EtherealStrengthSize, .data = EtherealStrength},
                              NULL));
     TEST_ASSERT_EQUAL(0, alloc.allocated_fragments);
     TEST_ASSERT_EQUAL(0, alloc.allocated_bytes);
@@ -984,7 +983,7 @@ static void testPushAnonymousService(void)
                              1234567890U,
                              meta,
                              (UdpardUDPIPEndpoint){.ip_address = 0xBABADEDAU, .udp_port = 0xD0ED},
-                             (UdpardConstPayload){.size = EtherealStrengthSize, .data = EtherealStrength},
+                             (UdpardPayload){.size = EtherealStrengthSize, .data = EtherealStrength},
                              NULL));
     TEST_ASSERT_EQUAL(0, alloc.allocated_fragments);
     TEST_ASSERT_EQUAL(0, alloc.allocated_bytes);

--- a/tests/src/test_tx.cpp
+++ b/tests/src/test_tx.cpp
@@ -31,7 +31,7 @@ void testInit()
     {
         const UdpardMemoryResource memory{
             .user_reference = &user_referent,
-            .free           = &dummyAllocatorFree,
+            .deallocate     = &dummyAllocatorDeallocate,
             .allocate       = &dummyAllocatorAllocate,
         };
         TEST_ASSERT_EQUAL(-UDPARD_ERROR_ARGUMENT, udpardTxInit(nullptr, &node_id, 0, memory));
@@ -40,7 +40,7 @@ void testInit()
         UdpardTx                   tx{};
         const UdpardMemoryResource memory{
             .user_reference = &user_referent,
-            .free           = &dummyAllocatorFree,
+            .deallocate     = &dummyAllocatorDeallocate,
             .allocate       = &dummyAllocatorAllocate,
         };
         TEST_ASSERT_EQUAL(-UDPARD_ERROR_ARGUMENT, udpardTxInit(&tx, nullptr, 0, memory));
@@ -49,7 +49,7 @@ void testInit()
         UdpardTx                   tx{};
         const UdpardMemoryResource memory{
             .user_reference = &user_referent,
-            .free           = &dummyAllocatorFree,
+            .deallocate     = &dummyAllocatorDeallocate,
             .allocate       = nullptr,
         };
         TEST_ASSERT_EQUAL(-UDPARD_ERROR_ARGUMENT, udpardTxInit(&tx, &node_id, 0, memory));
@@ -58,7 +58,7 @@ void testInit()
         UdpardTx                   tx{};
         const UdpardMemoryResource memory{
             .user_reference = &user_referent,
-            .free           = nullptr,
+            .deallocate     = nullptr,
             .allocate       = &dummyAllocatorAllocate,
         };
         TEST_ASSERT_EQUAL(-UDPARD_ERROR_ARGUMENT, udpardTxInit(&tx, &node_id, 0, memory));
@@ -67,7 +67,7 @@ void testInit()
         UdpardTx                   tx{};
         const UdpardMemoryResource memory{
             .user_reference = &user_referent,
-            .free           = &dummyAllocatorFree,
+            .deallocate     = &dummyAllocatorDeallocate,
             .allocate       = &dummyAllocatorAllocate,
         };
         TEST_ASSERT_EQUAL(0, udpardTxInit(&tx, &node_id, 0, memory));


### PR DESCRIPTION
* Implement the common parts of the RX pipeline. At this point, about 90% of the work is done. All that is left is to add the basic public API wrappers for subscriptions and RPC-services. For details about the implementation of the RX pipeline refer to the line that says "Internally, the RX pipeline is arranged as follows".

* Slightly refactor the code added earlier to uphold orthogonality and avoid unnecessary duplication.

* Trivial renamings to keep names shorter, e.g.:
  * `UdpardConstPayload` -> `UdpardPayload` (const implied by default; there's also `UdpardMutablePayload`)
  * `UdpardPayloadFragmentHandle` -> `UdpardFragment`

* Establish an internal convention that functions named "Destroy" deallocate the passed memory while "Free" only deallocate the memory of the associated resources. This is not API-visible.

* Remove the `port_id` field from `UdpardRxPort` because it is not needed.

After this is merged, the remaining task is to simply implement the public RX pipeline functions on top of:

- `rxPortInit`
- `rxPortAcceptFrame`
- `rxPortFree`

The test coverage is supposed to be full but llvm-cov slightly misreports it.