### PR TITLE
Add RPC service support to the RX pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,7 +142,7 @@ jobs:
           submodules: true
       - uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'zulu'
       # language=bash
       - run: |

--- a/libudpard/udpard.c
+++ b/libudpard/udpard.c
@@ -1773,7 +1773,7 @@ int_fast8_t udpardRxRPCDispatcherCancel(struct UdpardRxRPCDispatcher* const self
         UdpardPortID                  service_id_mutable = service_id;
         struct UdpardTreeNode** const root               = is_request ? &self->request_ports : &self->response_ports;
         struct UdpardRxRPC* const     item =
-            (struct UdpardRxRPC*) cavlSearch(root, &service_id_mutable, &rxRPCSearchByServiceID, NULL);
+            (struct UdpardRxRPC*) (void*) cavlSearch(root, &service_id_mutable, &rxRPCSearchByServiceID, NULL);
         if (item != NULL)
         {
             cavlRemove(root, &item->base);

--- a/libudpard/udpard.c
+++ b/libudpard/udpard.c
@@ -1698,22 +1698,24 @@ int_fast8_t udpardRxSubscriptionReceive(struct UdpardRxSubscription* const self,
                                         const uint_fast8_t                 redundant_iface_index,
                                         struct UdpardRxTransfer* const     out_transfer)
 {
-    bool        release = true;
-    int_fast8_t result  = -UDPARD_ERROR_ARGUMENT;
+    int_fast8_t result = -UDPARD_ERROR_ARGUMENT;
     if ((self != NULL) && (timestamp_usec != TIMESTAMP_UNSET) && (datagram_payload.data != NULL) &&
         (redundant_iface_index < UDPARD_NETWORK_INTERFACE_COUNT_MAX) && (out_transfer != NULL))
     {
-        result  = rxPortAcceptFrame(&self->port,
+        result = rxPortAcceptFrame(&self->port,
                                    redundant_iface_index,
                                    timestamp_usec,
                                    datagram_payload,
                                    self->memory,
                                    out_transfer);
-        release = false;
     }
-    if ((self != NULL) && release)
+    else if (self != NULL)
     {
         memFreePayload(self->memory.payload, datagram_payload);
+    }
+    else
+    {
+        (void) 0;
     }
     return result;
 }
@@ -1827,13 +1829,13 @@ int_fast8_t udpardRxRPCDispatcherReceive(struct UdpardRxRPCDispatcher* const sel
                                       self->memory,
                                       &out_transfer->base);
                 release = false;
-            }
+            }  // else, the application is not interested in this service-ID (does not know how to handle it).
             // Expose the port instance to the caller if requested.
             if (out_port != NULL)
             {
                 *out_port = item;
             }
-        }
+        }  // else, we didn't accept so we just ignore this frame
     }
     if ((self != NULL) && release)
     {

--- a/libudpard/udpard.c
+++ b/libudpard/udpard.c
@@ -1809,11 +1809,11 @@ int_fast8_t udpardRxRPCDispatcherReceive(struct UdpardRxRPCDispatcher* const sel
             out_transfer->service_id = frame.meta.data_specifier & DATA_SPECIFIER_SERVICE_ID_MASK;
             // Search for the RPC-port that is registered for this service transfer in the tree.
             struct UdpardRxRPC* const item =
-                (struct UdpardRxRPC*) cavlSearch(out_transfer->is_request ? &self->request_ports
-                                                                          : &self->response_ports,
-                                                 &out_transfer->service_id,
-                                                 &rxRPCSearchByServiceID,
-                                                 NULL);
+                (struct UdpardRxRPC*) (void*) cavlSearch(out_transfer->is_request ? &self->request_ports
+                                                                                  : &self->response_ports,
+                                                         &out_transfer->service_id,
+                                                         &rxRPCSearchByServiceID,
+                                                         NULL);
             // If such a port is found, accept the frame on it.
             if (item != NULL)
             {

--- a/libudpard/udpard.h
+++ b/libudpard/udpard.h
@@ -844,7 +844,9 @@ void udpardRxSubscriptionFree(struct UdpardRxSubscription* const self);
 /// fragment of the reassembled transfer payload or free it using the corresponding memory resource
 /// (see UdpardRxMemoryResources) if the datagram is not needed for reassembly. Because of the ownership transfer,
 /// the datagram payload buffer has to be mutable (non-const).
-/// In the case of an invalid argument error the library will attempt to free the datagram payload buffer.
+/// One exception is that if the "self" pointer is invalid, the library will be unable to process or free the datagram,
+/// which may lead to a memory leak in the application; hence, the caller should always check that the "self" pointer
+/// is always valid.
 ///
 /// The accepted datagram may either be invalid, carry a non-final part of a multi-frame transfer,
 /// carry a final part of a valid multi-frame transfer, or carry a valid single-frame transfer.
@@ -1020,6 +1022,8 @@ int_fast8_t udpardRxRPCDispatcherCancel(struct UdpardRxRPCDispatcher* const self
 /// Datagrams received from the sockets of this RPC service dispatcher are fed into this function.
 /// It is the analog of udpardRxSubscriptionReceive for RPC-service transfers.
 /// Please refer to the documentation of udpardRxSubscriptionReceive for the usage information.
+///
+/// Frames (datagrams) that belong to transfers for which there is no active RX RPC port are ignored.
 ///
 /// The "out_port" pointer-to-pointer can be used to retrieve the specific UdpardRxRPCPort instance that was used to
 /// process the received transfer. Remember that each UdpardRxRPCPort instance has a user reference field,

--- a/libudpard/udpard.h
+++ b/libudpard/udpard.h
@@ -488,6 +488,7 @@ struct UdpardTxItem
 /// The instance does not hold any resources itself except for the allocated memory.
 /// To safely discard it, simply pop all enqueued frames from it.
 ///
+/// The return value is zero on success, otherwise it is a negative error code.
 /// The time complexity is constant. This function does not invoke the dynamic memory manager.
 int_fast8_t udpardTxInit(struct UdpardTx* const            self,
                          const UdpardNodeID* const         local_node_id,

--- a/tests/src/test_intrusive_rx.c
+++ b/tests/src/test_intrusive_rx.c
@@ -334,6 +334,7 @@ static void testParseFrameEmpty(void)
 
 static void testParseFrameInvalidTransferID(void)
 {
+    // The transfer-ID offset is 8 bytes, starting from-->|
     byte_t  data[] = {1,   2,   41,  9,   56, 21, 230, 29, 255, 255, 255, 255,
                       255, 255, 255, 255, 57, 48, 0,   0,  0,   0,   42,  107,  //
                       'a', 'b', 'c'};

--- a/tests/src/test_rx.cpp
+++ b/tests/src/test_rx.cpp
@@ -272,6 +272,18 @@ void testRxRPCDispatcher()
     TEST_ASSERT_NOT_NULL(self.request_ports);
     TEST_ASSERT_NOT_NULL(self.response_ports);
 
+    // Add another response port.
+    UdpardRxRPCPort port_response_baz{};
+    TEST_ASSERT_EQUAL(1, udpardRxRPCDispatcherListen(&self, &port_response_baz, 9, false, 50));  // Added successfully.
+    TEST_ASSERT_EQUAL(0, udpardRxRPCDispatcherListen(&self, &port_response_baz, 9, false, 50));  // Re-added.
+    TEST_ASSERT_EQUAL(9, port_response_baz.service_id);
+    TEST_ASSERT_EQUAL(UDPARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC, port_response_baz.port.transfer_id_timeout_usec);
+    TEST_ASSERT_EQUAL(50, port_response_baz.port.extent);
+    TEST_ASSERT_NULL(port_response_baz.port.sessions);
+    TEST_ASSERT_NULL(port_response_baz.user_reference);
+    TEST_ASSERT_NOT_NULL(self.request_ports);
+    TEST_ASSERT_NOT_NULL(self.response_ports);
+
     // Check the global states.
     TEST_ASSERT_EQUAL(0, mem_session.allocated_fragments);
     TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
@@ -453,6 +465,7 @@ void testRxRPCDispatcher()
     // Remove the ports.
     TEST_ASSERT_EQUAL(0, udpardRxRPCDispatcherCancel(&self, 511, false));  // No such port.
     TEST_ASSERT_EQUAL(0, udpardRxRPCDispatcherCancel(&self, 0, true));     // No such port.
+    TEST_ASSERT_EQUAL(0, udpardRxRPCDispatcherCancel(&self, 9, true));     // No such port.
 
     TEST_ASSERT_EQUAL(1, udpardRxRPCDispatcherCancel(&self, 511, true));  // Removed.
     TEST_ASSERT_NULL(self.request_ports);
@@ -463,6 +476,13 @@ void testRxRPCDispatcher()
 
     TEST_ASSERT_EQUAL(1, udpardRxRPCDispatcherCancel(&self, 0, false));  // Removed.
     TEST_ASSERT_NULL(self.request_ports);
+    TEST_ASSERT_NOT_NULL(self.response_ports);
+    TEST_ASSERT_EQUAL(0, mem_session.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);
+
+    TEST_ASSERT_EQUAL(1, udpardRxRPCDispatcherCancel(&self, 9, false));  // Removed.
+    TEST_ASSERT_NULL(self.request_ports);
     TEST_ASSERT_NULL(self.response_ports);
     TEST_ASSERT_EQUAL(0, mem_session.allocated_fragments);
     TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
@@ -470,6 +490,7 @@ void testRxRPCDispatcher()
 
     TEST_ASSERT_EQUAL(0, udpardRxRPCDispatcherCancel(&self, 511, true));  // Idempotency.
     TEST_ASSERT_EQUAL(0, udpardRxRPCDispatcherCancel(&self, 0, false));   // Idempotency.
+    TEST_ASSERT_EQUAL(0, udpardRxRPCDispatcherCancel(&self, 9, false));   // Idempotency.
 
     TEST_ASSERT_EQUAL(-UDPARD_ERROR_ARGUMENT, udpardRxRPCDispatcherCancel(&self, 0xFFFF, true));
     TEST_ASSERT_EQUAL(-UDPARD_ERROR_ARGUMENT, udpardRxRPCDispatcherCancel(nullptr, 123, false));

--- a/tests/src/test_rx.cpp
+++ b/tests/src/test_rx.cpp
@@ -198,6 +198,283 @@ void testRxSubscriptionReceiveInvalidArgument()
     TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);
 }
 
+void testRxRPCDispatcher()
+{
+    InstrumentedAllocator mem_session{};
+    InstrumentedAllocator mem_fragment{};
+    InstrumentedAllocator mem_payload{};
+    instrumentedAllocatorNew(&mem_session);
+    instrumentedAllocatorNew(&mem_fragment);
+    instrumentedAllocatorNew(&mem_payload);
+
+    // Initialize the RPC dispatcher.
+    UdpardRxRPCDispatcher self{};
+    TEST_ASSERT_EQUAL(-UDPARD_ERROR_ARGUMENT,
+                      udpardRxRPCDispatcherInit(nullptr,
+                                                0xFFFFU,
+                                                {
+                                                    .session  = instrumentedAllocatorMakeMemoryResource(&mem_session),
+                                                    .fragment = instrumentedAllocatorMakeMemoryResource(&mem_fragment),
+                                                    .payload  = instrumentedAllocatorMakeMemoryDeleter(&mem_payload),
+                                                }));
+    TEST_ASSERT_EQUAL(-UDPARD_ERROR_ARGUMENT,
+                      udpardRxRPCDispatcherInit(&self,
+                                                0x1042,
+                                                {
+                                                    .session  = {nullptr, nullptr, nullptr},
+                                                    .fragment = instrumentedAllocatorMakeMemoryResource(&mem_fragment),
+                                                    .payload  = instrumentedAllocatorMakeMemoryDeleter(&mem_payload),
+                                                }));
+    TEST_ASSERT_EQUAL(0,
+                      udpardRxRPCDispatcherInit(&self,
+                                                0x1042,
+                                                {
+                                                    .session  = instrumentedAllocatorMakeMemoryResource(&mem_session),
+                                                    .fragment = instrumentedAllocatorMakeMemoryResource(&mem_fragment),
+                                                    .payload  = instrumentedAllocatorMakeMemoryDeleter(&mem_payload),
+                                                }));
+    TEST_ASSERT_EQUAL(&instrumentedAllocatorAllocate, self.memory.session.allocate);
+    TEST_ASSERT_EQUAL(&instrumentedAllocatorDeallocate, self.memory.session.deallocate);
+    TEST_ASSERT_NULL(self.request_ports);
+    TEST_ASSERT_NULL(self.response_ports);
+    TEST_ASSERT_EQUAL(0x1042, self.local_node_id);
+    TEST_ASSERT_EQUAL(0xEF011042UL, self.udp_ip_endpoint.ip_address);
+    TEST_ASSERT_EQUAL(9382, self.udp_ip_endpoint.udp_port);
+    TEST_ASSERT_EQUAL(0, mem_session.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);
+
+    // Add a request port.
+    UdpardRxRPCPort port_request_foo{};
+    TEST_ASSERT_EQUAL(-UDPARD_ERROR_ARGUMENT, udpardRxRPCDispatcherListen(&self, nullptr, 511, true, 100));
+    TEST_ASSERT_EQUAL(-UDPARD_ERROR_ARGUMENT, udpardRxRPCDispatcherListen(&self, &port_request_foo, 0xFFFF, true, 100));
+    TEST_ASSERT_EQUAL(1, udpardRxRPCDispatcherListen(&self, &port_request_foo, 511, true, 0));  // Added successfully.
+    TEST_ASSERT_EQUAL(0, udpardRxRPCDispatcherListen(&self, &port_request_foo, 511, true, 0));  // Re-added.
+    TEST_ASSERT_EQUAL(511, port_request_foo.service_id);
+    TEST_ASSERT_EQUAL(UDPARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC, port_request_foo.port.transfer_id_timeout_usec);
+    TEST_ASSERT_EQUAL(0, port_request_foo.port.extent);
+    TEST_ASSERT_NULL(port_request_foo.port.sessions);
+    TEST_ASSERT_NULL(port_request_foo.user_reference);
+    TEST_ASSERT_NOT_NULL(self.request_ports);
+    TEST_ASSERT_NULL(self.response_ports);
+
+    // Add a response port.
+    UdpardRxRPCPort port_response_bar{};
+    TEST_ASSERT_EQUAL(-UDPARD_ERROR_ARGUMENT, udpardRxRPCDispatcherListen(&self, nullptr, 0, false, 0));
+    TEST_ASSERT_EQUAL(-UDPARD_ERROR_ARGUMENT, udpardRxRPCDispatcherListen(&self, &port_response_bar, 0xFFFF, false, 0));
+    TEST_ASSERT_EQUAL(1, udpardRxRPCDispatcherListen(&self, &port_response_bar, 0, false, 100));  // Added successfully.
+    TEST_ASSERT_EQUAL(0, udpardRxRPCDispatcherListen(&self, &port_response_bar, 0, false, 100));  // Re-added.
+    TEST_ASSERT_EQUAL(0, port_response_bar.service_id);
+    TEST_ASSERT_EQUAL(UDPARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC, port_response_bar.port.transfer_id_timeout_usec);
+    TEST_ASSERT_EQUAL(100, port_response_bar.port.extent);
+    TEST_ASSERT_NULL(port_response_bar.port.sessions);
+    TEST_ASSERT_NULL(port_response_bar.user_reference);
+    TEST_ASSERT_NOT_NULL(self.request_ports);
+    TEST_ASSERT_NOT_NULL(self.response_ports);
+
+    // Check the global states.
+    TEST_ASSERT_EQUAL(0, mem_session.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);
+
+    // Feed a valid request for the existing port we created above.
+    //
+    //>>> from pycyphal.transport.commons.crc import CRC32C
+    //>>> CRC32C.new(b"Hello!").value_as_bytes
+    //
+    // >>> from pycyphal.transport.udp import UDPFrame
+    // >>> from pycyphal.transport import Priority, MessageDataSpecifier, ServiceDataSpecifier
+    // >>> frame = UDPFrame(priority=Priority.SLOW, transfer_id=0xbadc0ffee0ddf00d, index=0, end_of_transfer=True,
+    //  payload=memoryview(b'Hello!\xd6\xeb\xfd\t'), source_node_id=2345, destination_node_id=0x1042,
+    //  data_specifier=ServiceDataSpecifier(511, ServiceDataSpecifier.Role.REQUEST), user_data=0)
+    // >>> list(frame.compile_header_and_payload()[0])
+    // >>> list(frame.compile_header_and_payload()[1])
+    UdpardRxRPCPort*    out_port = nullptr;
+    UdpardRxRPCTransfer transfer{};
+    {
+        const std::array<std::uint_fast8_t, 34> data{{1,   6,   41,  9,   66,  16, 255, 193, 13,  240, 221, 224,
+                                                      254, 15,  220, 186, 0,   0,  0,   128, 0,   0,   111, 105,  //
+                                                      72,  101, 108, 108, 111, 33, 214, 235, 253, 9}};
+        const UdpardMutablePayload              datagram{
+                         .size = sizeof(data),
+                         .data = instrumentedAllocatorAllocate(&mem_payload, sizeof(data)),
+        };
+        TEST_ASSERT_NOT_NULL(datagram.data);
+        std::memcpy(datagram.data, data.data(), data.size());
+        TEST_ASSERT_EQUAL(1, udpardRxRPCDispatcherReceive(&self, 10'000'000, datagram, 2, &out_port, &transfer));
+    }
+    TEST_ASSERT_EQUAL(&port_request_foo, out_port);  // Points to the correct port.
+    TEST_ASSERT_EQUAL(511, transfer.service_id);
+    TEST_ASSERT_EQUAL(true, transfer.is_request);
+    TEST_ASSERT_EQUAL(10'000'000, transfer.base.timestamp_usec);
+    TEST_ASSERT_EQUAL(UdpardPrioritySlow, transfer.base.priority);
+    TEST_ASSERT_EQUAL(2345, transfer.base.source_node_id);
+    TEST_ASSERT_EQUAL(0xBADC0FFEE0DDF00D, transfer.base.transfer_id);
+    TEST_ASSERT_EQUAL(0, transfer.base.payload_size);  // Truncated away because extent zero.
+    TEST_ASSERT_EQUAL(0, transfer.base.payload.view.size);
+    TEST_ASSERT_NULL(transfer.base.payload.next);
+    // Check the global states.
+    TEST_ASSERT_EQUAL(1, mem_session.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);  // Because the payload was truncated away.
+    udpardRxFragmentFree(transfer.base.payload, self.memory.fragment, self.memory.payload);  // No-op.
+    TEST_ASSERT_EQUAL(1, mem_session.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);
+
+    // Feed the same transfer as before through another interface. It will be rejected as it is a duplicate.
+    {
+        const std::array<std::uint_fast8_t, 34> data{{1,   6,   41,  9,   66,  16, 255, 193, 13,  240, 221, 224,
+                                                      254, 15,  220, 186, 0,   0,  0,   128, 0,   0,   111, 105,  //
+                                                      72,  101, 108, 108, 111, 33, 214, 235, 253, 9}};
+        const UdpardMutablePayload              datagram{
+                         .size = sizeof(data),
+                         .data = instrumentedAllocatorAllocate(&mem_payload, sizeof(data)),
+        };
+        TEST_ASSERT_NOT_NULL(datagram.data);
+        std::memcpy(datagram.data, data.data(), data.size());
+        TEST_ASSERT_EQUAL(0, udpardRxRPCDispatcherReceive(&self, 10'001'000, datagram, 0, nullptr, &transfer));
+    }
+    // Check the global states.
+    TEST_ASSERT_EQUAL(1, mem_session.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);
+
+    // Feed a valid response for the existing port we created above.
+    //
+    // >>> frame = UDPFrame(priority=Priority.OPTIONAL, transfer_id=0x123456789ABCDEF, index=0, end_of_transfer=True,
+    // payload=memoryview(b'Hello!\xd6\xeb\xfd\t'), source_node_id=5432, destination_node_id=0x1042,
+    // data_specifier=ServiceDataSpecifier(0, ServiceDataSpecifier.Role.RESPONSE), user_data=0)
+    {
+        const std::array<std::uint_fast8_t, 34> data{{1,   7,   56,  21,  66,  16, 0,   128, 239, 205, 171, 137,
+                                                      103, 69,  35,  1,   0,   0,  0,   128, 0,   0,   164, 48,  //
+                                                      72,  101, 108, 108, 111, 33, 214, 235, 253, 9}};
+        const UdpardMutablePayload              datagram{
+                         .size = sizeof(data),
+                         .data = instrumentedAllocatorAllocate(&mem_payload, sizeof(data)),
+        };
+        TEST_ASSERT_NOT_NULL(datagram.data);
+        std::memcpy(datagram.data, data.data(), data.size());
+        TEST_ASSERT_EQUAL(1, udpardRxRPCDispatcherReceive(&self, 10'002'000, datagram, 1, &out_port, &transfer));
+    }
+    TEST_ASSERT_EQUAL(&port_response_bar, out_port);  // Points to the correct port.
+    TEST_ASSERT_EQUAL(0, transfer.service_id);
+    TEST_ASSERT_EQUAL(false, transfer.is_request);
+    TEST_ASSERT_EQUAL(10'002'000, transfer.base.timestamp_usec);
+    TEST_ASSERT_EQUAL(UdpardPriorityOptional, transfer.base.priority);
+    TEST_ASSERT_EQUAL(5432, transfer.base.source_node_id);
+    TEST_ASSERT_EQUAL(0x123456789ABCDEF, transfer.base.transfer_id);
+    TEST_ASSERT_EQUAL(6, transfer.base.payload_size);
+    TEST_ASSERT_EQUAL(6, transfer.base.payload.view.size);
+    TEST_ASSERT_EQUAL_MEMORY("Hello!", transfer.base.payload.view.data, 6);
+    TEST_ASSERT_NULL(transfer.base.payload.next);
+    // Check the global states.
+    TEST_ASSERT_EQUAL(2, mem_session.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
+    TEST_ASSERT_EQUAL(1, mem_payload.allocated_fragments);
+    udpardRxFragmentFree(transfer.base.payload, self.memory.fragment, self.memory.payload);
+    TEST_ASSERT_EQUAL(2, mem_session.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);
+
+    // Feed another valid transfer for which there is no port. It will be ignored.
+    // >>> frame = UDPFrame(priority=Priority.OPTIONAL, transfer_id=0x123456789ABCDEF, index=0, end_of_transfer=True,
+    // payload=memoryview(b'Hello!\xd6\xeb\xfd\t'), source_node_id=5432, destination_node_id=0x1042,
+    // data_specifier=ServiceDataSpecifier(123, ServiceDataSpecifier.Role.RESPONSE), user_data=0)
+    {
+        const std::array<std::uint_fast8_t, 34> data{{1,   7,   56,  21,  66,  16, 123, 128, 239, 205, 171, 137,
+                                                      103, 69,  35,  1,   0,   0,  0,   128, 0,   0,   180, 206,  //
+                                                      72,  101, 108, 108, 111, 33, 214, 235, 253, 9}};
+        const UdpardMutablePayload              datagram{
+                         .size = sizeof(data),
+                         .data = instrumentedAllocatorAllocate(&mem_payload, sizeof(data)),
+        };
+        TEST_ASSERT_NOT_NULL(datagram.data);
+        std::memcpy(datagram.data, data.data(), data.size());
+        TEST_ASSERT_EQUAL(0, udpardRxRPCDispatcherReceive(&self, 10'003'000, datagram, 1, &out_port, &transfer));
+    }
+    TEST_ASSERT_NULL(out_port);  // No port.
+    TEST_ASSERT_EQUAL(2, mem_session.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);
+
+    // Feed another valid transfer on the correct port but addressed to the wrong node.
+    // >>> frame = UDPFrame(priority=Priority.OPTIONAL, transfer_id=0x123456789ABCDEF, index=0, end_of_transfer=True,
+    // payload=memoryview(b'Hello!\xd6\xeb\xfd\t'), source_node_id=5432, destination_node_id=1234,
+    // data_specifier=ServiceDataSpecifier(0, ServiceDataSpecifier.Role.RESPONSE), user_data=0)
+    {
+        const std::array<std::uint_fast8_t, 34> data{{1,   7,   56,  21,  210, 4,  0,   128, 239, 205, 171, 137,
+                                                      103, 69,  35,  1,   0,   0,  0,   128, 0,   0,   236, 89,  //
+                                                      72,  101, 108, 108, 111, 33, 214, 235, 253, 9}};
+        const UdpardMutablePayload              datagram{
+                         .size = sizeof(data),
+                         .data = instrumentedAllocatorAllocate(&mem_payload, sizeof(data)),
+        };
+        TEST_ASSERT_NOT_NULL(datagram.data);
+        std::memcpy(datagram.data, data.data(), data.size());
+        TEST_ASSERT_EQUAL(0, udpardRxRPCDispatcherReceive(&self, 10'004'000, datagram, 1, nullptr, &transfer));
+    }
+    TEST_ASSERT_EQUAL(2, mem_session.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);
+
+    // Feed an invalid frame. Ensure it is freed regardless.
+    TEST_ASSERT_EQUAL(0,
+                      udpardRxRPCDispatcherReceive(&self,
+                                                   10'005'000,
+                                                   UdpardMutablePayload{
+                                                       .size = 100,
+                                                       .data = instrumentedAllocatorAllocate(&mem_payload, 100),
+                                                   },
+                                                   1,
+                                                   nullptr,
+                                                   &transfer));
+    TEST_ASSERT_EQUAL(2, mem_session.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);  // Freed.
+
+    // Invalid arguments. The memory is freed as long as self is valid.
+    TEST_ASSERT_EQUAL(-UDPARD_ERROR_ARGUMENT,
+                      udpardRxRPCDispatcherReceive(&self,
+                                                   0,
+                                                   UdpardMutablePayload{
+                                                       .size = 100,
+                                                       .data = instrumentedAllocatorAllocate(&mem_payload, 100),
+                                                   },
+                                                   1,
+                                                   nullptr,
+                                                   nullptr));
+    TEST_ASSERT_EQUAL(2, mem_session.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);  // Freed.
+    TEST_ASSERT_EQUAL(-UDPARD_ERROR_ARGUMENT,
+                      udpardRxRPCDispatcherReceive(nullptr, 0, UdpardMutablePayload{}, 1, nullptr, nullptr));
+
+    // Remove the ports.
+    TEST_ASSERT_EQUAL(0, udpardRxRPCDispatcherCancel(&self, 511, false));  // No such port.
+    TEST_ASSERT_EQUAL(0, udpardRxRPCDispatcherCancel(&self, 0, true));     // No such port.
+
+    TEST_ASSERT_EQUAL(1, udpardRxRPCDispatcherCancel(&self, 511, true));  // Removed.
+    TEST_ASSERT_NULL(self.request_ports);
+    TEST_ASSERT_NOT_NULL(self.response_ports);
+    TEST_ASSERT_EQUAL(1, mem_session.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);
+
+    TEST_ASSERT_EQUAL(1, udpardRxRPCDispatcherCancel(&self, 0, false));  // Removed.
+    TEST_ASSERT_NULL(self.request_ports);
+    TEST_ASSERT_NULL(self.response_ports);
+    TEST_ASSERT_EQUAL(0, mem_session.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_fragment.allocated_fragments);
+    TEST_ASSERT_EQUAL(0, mem_payload.allocated_fragments);
+
+    TEST_ASSERT_EQUAL(0, udpardRxRPCDispatcherCancel(&self, 511, true));  // Idempotency.
+    TEST_ASSERT_EQUAL(0, udpardRxRPCDispatcherCancel(&self, 0, false));   // Idempotency.
+
+    TEST_ASSERT_EQUAL(-UDPARD_ERROR_ARGUMENT, udpardRxRPCDispatcherCancel(&self, 0xFFFF, true));
+    TEST_ASSERT_EQUAL(-UDPARD_ERROR_ARGUMENT, udpardRxRPCDispatcherCancel(nullptr, 123, false));
+}
+
 }  // namespace
 
 void setUp() {}
@@ -210,5 +487,6 @@ int main()
     RUN_TEST(testRxSubscriptionInit);
     RUN_TEST(testRxSubscriptionReceive);
     RUN_TEST(testRxSubscriptionReceiveInvalidArgument);
+    RUN_TEST(testRxRPCDispatcher);
     return UNITY_END();
 }


### PR DESCRIPTION
This is the final feature.

This changeset slightly modifies the error handling behavior of `udpardRxSubscriptionReceive` such that the datagram is deallocated if the passed arguments are invalid, unless `self` is also invalid. This is needed to prevent memory leak when the function is invoked incorrectly. An alternative solution is to state it explicitly in the API that the caller is required to free the datagram memory if `-UDPARD_ERROR_ARGUMENT` is returned, but this convention is comparatively fragile. A new test is added for this.

`UdpardRxRPC` is renamed into `UdpardRxRPCPort` for clarity.

`UdpardRxRPCDispatcher` is extended with `local_node_id` to facilitate destination address check when accepting frames.

After this one is accepted, the next steps are:
- The internal e2e test (I am currently working on it).
- A demo application in C that also serves as a high-level integration test. My original plan was to make it interact with a PyCyphal script but I am now considering a slightly different approach where the interaction will be arranged with a simple bash script based on Yakut. Stay tuned.